### PR TITLE
set-model : Fixed parsing of arguments

### DIFF
--- a/app/cli/cmd/set_model.go
+++ b/app/cli/cmd/set_model.go
@@ -125,7 +125,7 @@ func modelsSet(cmd *cobra.Command, args []string) {
 
 	if len(args) > 1 {
 		if role != "" {
-			propertyCompact = shared.Compact(args[1])
+			propertyCompact = args[1]
 		} else {
 			value = args[1]
 		}


### PR DESCRIPTION
Issue https://github.com/plandex-ai/plandex/issues/75

Tested these commands from https://github.com/plandex-ai/plandex/blob/main/guides/USAGE.md#model-settings-

```
plandex models # show the current AI models and model settings
plandex set-model # select from a list of models and settings
plandex set-model planner gpt-4 # set the main planner model to gpt-4
plandex set-model builder temperature 0.1 # set the builder model's temperature to 0.1
plandex set-model max-tokens 4000 # set the planner model overall token limit to 4000
plandex set-model max-convo-tokens 20000  # set how large the conversation can grow before Plandex starts using summaries
```