### PR TITLE
fix automatic CLI upgrade issue on WSL and Pop!_OS

### DIFF
--- a/app/cli/upgrade.go
+++ b/app/cli/upgrade.go
@@ -3,8 +3,10 @@ package main
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net/http"
 	"net/url"
@@ -135,7 +137,7 @@ func doUpgrade(version string) error {
 		if header.Typeflag == tar.TypeReg && (header.Name == "plandex" || header.Name == "plandex.exe") {
 			err = update.Apply(tarReader, update.Options{})
 			if err != nil {
-				if os.IsPermission(err) {
+				if errors.Is(err, fs.ErrPermission) {
 					return fmt.Errorf("failed to apply update due to permission error, please try running again with 'sudo': %w", err)
 				}
 				return fmt.Errorf("failed to apply update: %w", err)

--- a/app/cli/upgrade.go
+++ b/app/cli/upgrade.go
@@ -135,6 +135,9 @@ func doUpgrade(version string) error {
 		if header.Typeflag == tar.TypeReg && (header.Name == "plandex" || header.Name == "plandex.exe") {
 			err = update.Apply(tarReader, update.Options{})
 			if err != nil {
+				if os.IsPermission(err) {
+					return fmt.Errorf("failed to apply update due to permission error, please try running again with 'sudo': %w", err)
+				}
 				return fmt.Errorf("failed to apply update: %w", err)
 			}
 			break


### PR DESCRIPTION
Fix #97. This pull request fixes the issue where the automatic CLI upgrade was failing on WSL and Pop!_OS.