### PR TITLE
🔧 Add GitHub Actions Workflow to Build and Publish Docker Image on Re…

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: Build and publish Docker Image if a new GitHub release is created
+
+on:
+  release:
+    types: [created]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: plandex-server
+  DOCKER_CONTEXT: ./app/
+  DOCKERFILE_PATH: ./app/Dockerfile.server
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Verify Dockerfile syntax
+        run: docker run --rm -i hadolint/hadolint < ${{ env.DOCKERFILE_PATH }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ env.DOCKER_CONTEXT }}
+          file: ${{ env.DOCKERFILE_PATH }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Clean up Docker images
+        run: |
+          docker rmi ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          docker rmi ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to automate the process of building and publishing a Docker image to the GitHub Container Registry whenever a new GitHub release is created.

Key Features:

Automated Docker Image Creation: The workflow triggers upon the creation of a new GitHub release, ensuring that the latest version of the application is always available as a Docker image.
Container Registry Integration: The built Docker images are pushed to the GitHub Container Registry (ghcr.io), facilitating easy access and deployment for self-hosting.
Enhanced Workflow Efficiency:
Environment Variables: Utilizes environment variables for common values to enhance readability and maintainability.
Dockerfile Syntax Verification: Includes a step to verify the Dockerfile syntax using hadolint to catch errors early in the process.
Build Caching: Implements caching to speed up subsequent builds by reusing unchanged layers.
Image Cleanup: Cleans up Docker images after pushing to free up disk space on the runner.
By integrating this workflow, we streamline the release process and provide an efficient way for users to self-host the application using the latest Docker images.