### PR TITLE
Add support for the version schema to the GitHub Workflow 

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,9 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v1
         with:
@@ -19,14 +22,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Sanitize ref name
         id: sanitize
         run: echo "SANITIZED_REF_NAME=${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
 
+      - name: Check if the release tag starts with 'server'
+        id: check_tag
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^server ]]; then
+            echo "The tag does not start with 'server'."
+            exit 1
+          fi
+        shell: bash
+
       - name: Build and push
+        if: steps.check_tag.outcome == 'success'
         uses: docker/build-push-action@v2
         with:
           context: ./app/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_and_push:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -30,17 +30,18 @@ jobs:
         id: check_tag
         run: |
           if [[ ! "${GITHUB_REF_NAME}" =~ ^server ]]; then
-            echo "The tag does not start with 'server'."
-            echo "skip" >> $GITHUB_ENV
+            echo "::set-output name=skip::true"
+          else
+            echo "::set-output name=skip::false"
           fi
         shell: bash
 
       - name: Skip build if tag does not start with 'server'
-        if: env.skip == 'skip'
+        if: steps.check_tag.outputs.skip == 'true'
         run: echo "Skipping build because the tag does not start with 'server'."
 
       - name: Build and push
-        if: env.skip != 'skip'
+        if: steps.check_tag.outputs.skip == 'false'
         uses: docker/build-push-action@v2
         with:
           context: ./app/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,9 +7,7 @@ on:
 jobs:
   build_and_push:
     runs-on: ubuntu-latest
-    env:
-      SANITIZED_REF_NAME: ${{ github.ref_name && replace(github.ref_name, '/', '-') }}
-
+    
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -23,6 +21,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+
+      - name: Sanitize ref name
+        id: sanitize
+        run: echo "SANITIZED_REF_NAME=${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
 
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,12 +31,16 @@ jobs:
         run: |
           if [[ ! "${GITHUB_REF_NAME}" =~ ^server ]]; then
             echo "The tag does not start with 'server'."
-            exit 1
+            echo "skip" >> $GITHUB_ENV
           fi
         shell: bash
 
+      - name: Skip build if tag does not start with 'server'
+        if: env.skip == 'skip'
+        run: echo "Skipping build because the tag does not start with 'server'."
+
       - name: Build and push
-        if: steps.check_tag.outcome == 'success'
+        if: env.skip != 'skip'
         uses: docker/build-push-action@v2
         with:
           context: ./app/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,23 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Sanitize ref name
-        id: sanitize
-        run: echo "SANITIZED_REF_NAME=${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
-
       - name: Check if the release tag starts with 'server'
         id: check_tag
         run: |
@@ -39,6 +22,28 @@ jobs:
       - name: Skip build if tag does not start with 'server'
         if: steps.check_tag.outputs.skip == 'true'
         run: echo "Skipping build because the tag does not start with 'server'."
+
+      - name: Check out the repo
+        if: steps.check_tag.outputs.skip == 'false'
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        if: steps.check_tag.outputs.skip == 'false'
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        if: steps.check_tag.outputs.skip == 'false'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: Sanitize ref name
+        id: sanitize
+        if: steps.check_tag.outputs.skip == 'false'
+        run: echo "SANITIZED_REF_NAME=${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
 
       - name: Build and push
         if: steps.check_tag.outputs.skip == 'false'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build_and_push:
     runs-on: ubuntu-latest
+    env:
+      SANITIZED_REF_NAME: ${{ github.ref_name && replace(github.ref_name, '/', '-') }}
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -28,5 +31,5 @@ jobs:
           file: ./app/Dockerfile.server
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/plandex-server:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/plandex-server:${{ env.SANITIZED_REF_NAME }}
             ghcr.io/${{ github.repository_owner }}/plandex-server:latest


### PR DESCRIPTION
The current GitHub Workflow has issues with the version schema used in this project. 
The workflow was updated to support it.
Also, a check was added to only execute the workflow it if the git tag starts with "server"
