### PR TITLE
Enforce LF line endings for *.sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh		text eol=lf


### PR DESCRIPTION
Enforce LF line endings for *.sh files when checking out the project via git on Windows machines. 

This fixes #104