### PR TITLE
Make production in the _env file the default

### DIFF
--- a/app/_env
+++ b/app/_env
@@ -2,4 +2,4 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_USER=plandex
 PGDATA_DIR=/var/lib/postgresql/data
 PLANDEX_DATA_DIR=/var/lib/plandex/data
-GOENV=development
+GOENV=production


### PR DESCRIPTION
Using `development` as a default value causes the compose data by default to be non-persistent. This is likely unwanted.

This fixes #9