### PR TITLE
Make sure the start_local.sh runs in the correct directory

### DIFF
--- a/app/start_local.sh
+++ b/app/start_local.sh
@@ -20,6 +20,9 @@ if ! [ -x "$(command -v docker-compose)" ]; then
     exit 1
 fi
 
+# make sure that we are in the same directory as the script
+cd "$(dirname "$0")"
+
 # copy the _env file to .env unless it already exists
 if [ -f .env ]; then
     echo ".env file already exists, won't overwrite it with _env"


### PR DESCRIPTION
Currently, when following the Self-hosting guide, an error will occur due to not using the right working directory.