### PR TITLE
Add plain flag to diff

### DIFF
--- a/app/cli/cmd/diffs.go
+++ b/app/cli/cmd/diffs.go
@@ -28,7 +28,6 @@ func init() {
 }
 
 func diffs(cmd *cobra.Command, args []string) {
-	fmt.Println("HELLO DIFFS AGAIN")
 	auth.MustResolveAuthWithOrg()
 	lib.MaybeResolveProject()
 

--- a/app/cli/cmd/diffs.go
+++ b/app/cli/cmd/diffs.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"regexp"
+	"fmt"
 	"plandex/api"
 	"plandex/auth"
 	"plandex/lib"
@@ -8,6 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 )
+
+// var plainTextOutput bool
 
 var diffsCmd = &cobra.Command{
 	Use:     "diff",
@@ -18,9 +22,13 @@ var diffsCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(diffsCmd)
+
+	diffsCmd.Flags().BoolVarP(&plainTextOutput, "plain", "p", false, "Output diffs in plain text with no ANSI codes")
+
 }
 
 func diffs(cmd *cobra.Command, args []string) {
+	fmt.Println("HELLO DIFFS AGAIN")
 	auth.MustResolveAuthWithOrg()
 	lib.MaybeResolveProject()
 
@@ -35,5 +43,15 @@ func diffs(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	term.PageOutput(diffs)
+	if plainTextOutput {
+		fmt.Println(stripANSI(diffs))
+	} else {
+		term.PageOutput(diffs)
+	}
+}
+
+// stripANSI removes ANSI escape codes from the input string
+func stripANSI(input string) string {
+	ansiEscape := regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+	return ansiEscape.ReplaceAllString(input, "")
 }

--- a/app/cli/term/help.go
+++ b/app/cli/term/help.go
@@ -18,6 +18,7 @@ var CmdDesc = map[string][2]string{
 	"tell":    {"t", "describe a task, ask a question, or chat"},
 	"changes": {"ch", "review pending changes in a TUI"},
 	"diff":    {"", "review pending changes in 'git diff' format"},
+	"diff --plain":    {"", "review pending changes in 'git diff' format with no color formatting"},
 	"summary": {"", "show the latest summary of the current plan"},
 	// "preview":     {"pv", "preview the plan in a branch"},
 	"apply":     {"ap", "apply pending changes to project files"},
@@ -143,7 +144,7 @@ func PrintCustomHelp(all bool) {
 		fmt.Fprintln(builder)
 
 		color.New(color.Bold, color.BgCyan, color.FgHiWhite).Fprintln(builder, " Changes ")
-		printCmds(builder, " ", []color.Attribute{color.Bold, ColorHiCyan}, "changes", "diff", "apply", "reject")
+		printCmds(builder, " ", []color.Attribute{color.Bold, ColorHiCyan}, "changes", "diff", "diff --plain", "apply", "reject")
 		fmt.Fprintln(builder)
 
 		color.New(color.Bold, color.BgCyan, color.FgHiWhite).Fprintln(builder, " Context ")

--- a/app/scripts/dev.sh
+++ b/app/scripts/dev.sh
@@ -18,7 +18,7 @@ if ! [ -x "$(command -v reflex)" ]; then
 
   # Check if the $GOPATH is empty
   if [ -z "$GOPATH" ]; then
-    echo "Error: $GOPATH is not set. Please set it to continue..." >&2
+    echo "Error: GOPATH is not set. Please set it to continue..." >&2
     exit 1
   fi
 

--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -268,6 +268,8 @@ Review pending changes in 'git diff' format.
 plandex diff
 ```
 
+`--plain/-p`: Output diffs in plain text with no ANSI codes.
+
 ### changes
 
 Review pending changes in a TUI.

--- a/docs/docs/core-concepts/reviewing-changes.md
+++ b/docs/docs/core-concepts/reviewing-changes.md
@@ -15,7 +15,9 @@ When Plandex has finished with your task, you can review the proposed changes wi
 plandex diff
 ```
 
-Or you can view them in Plandex's changes TUI:
+`--plain/-p`: Outputs the conversation in plain text with no ANSI codes.
+
+You can also view them in Plandex's changes TUI:
 
 ```bash
 plandex changes


### PR DESCRIPTION
Added the command plandex diff --plain to provide the git differences in plain text.  Updated documentation and help commands accordingly.

Additionally, fixed a minor error message bug when trying to run ./app/scripts/dev.sh locally.  The error message now states that GOPATH is not set when it is not set.