### PR TITLE
Add initial shell completion support

### DIFF
--- a/app/cli/cmd/completion.go
+++ b/app/cli/cmd/completion.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionLongDesc = fmt.Sprintf(`To load completions:
+Bash:
+
+  $ source <(%[1]s completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ %[1]s completion bash > /etc/bash_completion.d/%[1]s
+  # macOS:
+  $ %[1]s completion bash > $(brew --prefix)/etc/bash_completion.d/%[1]s
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ %[1]s completion fish | source
+
+  # To load completions for each session, execute once:
+  $ %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish
+
+PowerShell:
+
+  PS> %[1]s completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> %[1]s completion powershell > %[1]s.ps1
+  # and source this file from your PowerShell profile.
+`, RootCmd.Name())
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long:  completionLongDesc,
+
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run:                   completion,
+}
+
+func init() {
+	RootCmd.AddCommand(completionCmd)
+}
+
+func completion(cmd *cobra.Command, args []string) {
+	switch args[0] {
+	case "bash":
+		cmd.Root().GenBashCompletion(os.Stdout)
+	case "zsh":
+		cmd.Root().GenZshCompletion(os.Stdout)
+	case "fish":
+		cmd.Root().GenFishCompletion(os.Stdout, true)
+	case "powershell":
+		cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+	}
+}

--- a/app/cli/cmd/tell.go
+++ b/app/cli/cmd/tell.go
@@ -30,7 +30,10 @@ var tellCmd = &cobra.Command{
 	Short:   "Send a prompt for the current plan",
 	// Long:  ``,
 	Args: cobra.RangeArgs(0, 1),
-	Run:  doTell,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	},
+	Run: doTell,
 }
 
 func init() {


### PR DESCRIPTION
This commit adds initial completion support. The commands can be adjusted over time to improve completions but this at least matches the commands.

The long description of the completion command was taken directly from [from Cobra's docs](https://github.com/spf13/cobra/blob/main/site/content/completions/_index.md).

![image](https://github.com/user-attachments/assets/a2d89290-48e8-43e9-920e-fcda5287c4bc)
