### PR TITLE
Dockerfile and CI Optimizations

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -105,6 +105,16 @@ jobs:
         id: go_version
         run: echo "GO_VERSION=$(grep '^go ' ./app/server/go.mod | awk '{print $2}')" >> $GITHUB_OUTPUT
 
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: plandexai/plandex-server
+          # Override this label and annotation
+          # since release event creates version in format release-<release-name>
+          labels: org.opencontainers.image.version=${{ steps.sanitize.outputs.SANITIZED_TAG_NAME }}
+          annotations: org.opencontainers.image.version=${{ steps.sanitize.outputs.SANITIZED_TAG_NAME }}
+
       - name: Build and push
         uses: docker/build-push-action@v6
         env:
@@ -115,6 +125,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: GO_VERSION=${{ steps.go_version.outputs.GO_VERSION }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           tags: |
             plandexai/plandex-server:${{ steps.sanitize.outputs.SANITIZED_TAG_NAME }}
             plandexai/plandex-server:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       should_build: ${{ steps.check_release.outputs.should_build }}
       tag: ${{ steps.check_release.outputs.tag }}
-    
+
     steps:
       - name: Check release tag and find latest server tag
         id: check_release
@@ -42,7 +42,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0  # Fetch all history and tags
+          fetch-depth: 0 # Fetch all history and tags
 
       - name: Find latest server tag
         id: find_tag
@@ -50,7 +50,7 @@ jobs:
         run: |
           # Find the latest tag that starts with 'server'
           LATEST_SERVER_TAG=$(git tag -l "server*" --sort=-creatordate | head -n 1)
-          
+
           if [ -z "$LATEST_SERVER_TAG" ]; then
             echo "No tags starting with 'server' found."
             echo "skip=true" >> $GITHUB_OUTPUT
@@ -101,6 +101,10 @@ jobs:
         id: sanitize
         run: echo "SANITIZED_TAG_NAME=$(echo ${{ steps.determine_tag.outputs.tag }} | tr '/' '-' | tr '+' '-')" >> $GITHUB_OUTPUT
 
+      - name: Extract Go version from go.mod
+        id: go_version
+        run: echo "GO_VERSION=$(grep '^go ' ./app/server/go.mod | awk '{print $2}')" >> $GITHUB_OUTPUT
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -108,6 +112,7 @@ jobs:
           file: ./app/server/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: GO_VERSION=${{ steps.go_version.outputs.GO_VERSION }}
           tags: |
             plandexai/plandex-server:${{ steps.sanitize.outputs.SANITIZED_TAG_NAME }}
             plandexai/plandex-server:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history and tags
 
@@ -75,13 +75,13 @@ jobs:
           exit 1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -106,7 +106,9 @@ jobs:
         run: echo "GO_VERSION=$(grep '^go ' ./app/server/go.mod | awk '{print $2}')" >> $GITHUB_OUTPUT
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: ./app/
           file: ./app/server/Dockerfile

--- a/app/server/Dockerfile.debug
+++ b/app/server/Dockerfile.debug
@@ -37,6 +37,15 @@ FROM scratch
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
+# Copy shell and other common utils for debug image
+COPY --from=builder /bin/sh /bin/sh
+COPY --from=builder /bin/chown /bin/chown
+COPY --from=builder /bin/mkdir /bin/mkdir
+COPY --from=builder /bin/cat /bin/cat
+COPY --from=builder /bin/ls /bin/ls
+COPY --from=builder /bin/echo /bin/echo
+COPY --from=builder /usr/bin/id /bin/id
+
 # Shared libraries needed for Git binary
 COPY --from=builder /lib/ld-musl-*.so.1 /lib/
 COPY --from=builder /lib/libz.so.1 /lib/
@@ -59,4 +68,5 @@ ENV MIGRATIONS_DIR=/home/plandex/migrations
 ENV PORT=8099
 EXPOSE 8099
 
-ENTRYPOINT ["plandex-server"]
+ENTRYPOINT ["sh", "-c"]
+CMD ["plandex-server"]


### PR DESCRIPTION

Hello, I want to introduce some improvements to the Docker build process and updates to the GitHub workflows. Here's a quick breakdown:

### What’s Changed:

**Dockerfile Improvements:**

-   The Dockerfile has been split into a multi-stage build, using `scratch` as the base for the final image, ensuring the smallest and most secure footprint. The final image contains only the `plandex-server` executable, Git with its dependent libraries, and a folder with DB migrations. The result is that the image size is around 60MB uncompressed, compared to almost 2GB for the current image available on DockerHub, with almost no CVEs detected.
    
-   The binary has been **statically linked**, making it more portable. The C library is statically linked into the executable because the `tree-sitter` dependency relies on it.
    
-   A **non-root user** (`plandex`) has been added for better security practices. The image also supports running as any user (uid) to comply with security profiles on container platforms like OpenShift restricted-v2.
    
-   Added a **debug Dockerfile** to help with development and troubleshooting. This version includes additional tools like `sh`, `mkdir`, `ls`, and `echo`, allowing you to exec into the image and troubleshoot easily.
    

**GitHub Workflow Updates:**

-   The workflow now dynamically detects the Go version from `go.mod` and passes it as a build argument.
    
-   Bumped the GitHub Actions versions (e.g., `actions/checkout@v2 → v4`) to keep everything up to date and avoid deprecation warnings.
    
-   Added Docker image metadata (annotations & labels).
    

**Testing:**

I’ve successfully tested the `linux/amd64` variant of the Docker image on **OpenShift**, running under the **restricted-v2** profile, ensuring the image works within a secure and restricted environment. However, I only tested basic functionality like `chat`, `tell`, and `apply`, not every CLI command.

Hope you find this helpful!