### PR TITLE
feat: improve context map for typescript files

### DIFF
--- a/app/server/handlers/file_maps_queue.go
+++ b/app/server/handlers/file_maps_queue.go
@@ -88,6 +88,7 @@ func mapWorker(job projectMapJob) {
 
 	for path, input := range job.inputs {
 		if !shared.HasFileMapSupport(path) {
+			log.Printf("mapWorker: Skipping unsupported file %s", path)
 			mu.Lock()
 			maps[path] = "[NO MAP]"
 			mu.Unlock()
@@ -108,7 +109,7 @@ func mapWorker(job projectMapJob) {
 			fileMap, err := file_map.MapFile(job.ctx, path, []byte(input))
 			if err != nil {
 				// Skip files that can't be parsed, just log the error
-				log.Printf("Error mapping file %s: %v", path, err)
+				log.Printf("mapWorker: Error mapping file %s: %v", path, err)
 				mu.Lock()
 				maps[path] = "[NO MAP]"
 				mu.Unlock()

--- a/app/server/syntax/file_map/map_test.go
+++ b/app/server/syntax/file_map/map_test.go
@@ -1,0 +1,132 @@
+package file_map
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMapTypescriptFile(t *testing.T) {
+	ctx := context.Background()
+
+	filename := "example.ts"
+	content := []byte(`
+// Type alias example
+export type Test = string;
+export type MyNumber = number;
+export type MyStringArray = string[];
+
+// Non-exported type alias
+type LocalType = boolean;
+
+// Function declaration
+export function MyFunction(a: number, b: string): boolean {
+    return a == b;
+}
+
+// Non-exported function
+function localFunction(a: number, b: string): boolean {
+    return true
+}
+
+// Constant declaration
+export const SOME_CONSTANT = 123;
+
+// Non-exported constant
+const localConstant = "local";
+
+// Variable declaration
+export var someVar = "hello";
+
+// Non-exported variable
+let localVar = "mutable";
+
+// Class declaration
+export class MyClass {
+    constructor(private a: number, b: string) {}
+
+    someMethod(a: number, b: string): boolean {
+        return a == b;
+    }
+}
+
+// Non-exported class
+class LocalClass {
+    member: number
+    method(str: string) {}
+}
+
+// Interface declaration
+export interface MyInterface {
+    prop: string;
+    method(a: number): void;
+}
+
+// Non-exported interface
+interface LocalInterface {
+    prop: string;
+    method(a: string): void;
+}
+
+// Enum declaration
+export enum MyEnum {
+    First = "first",
+    Second = "second",
+}
+
+// Non-exported enum
+enum LocalEnum {
+    One = 1,
+    Two = 2,
+}
+
+// Default export example
+export default class DefaultClass {}
+
+// Default export with named export
+export default function defaultFunction() {}
+export const anotherFunction = () => {};
+`)
+
+	fileMap, err := MapFile(ctx, filename, content)
+
+	if err != nil {
+		t.Fatalf("MapFile returned unexpected error: %v", err)
+	}
+
+	if fileMap == nil {
+		t.Fatal("MapFile returned nil fileMap")
+	}
+
+	expectedTypes := []string{
+		"type_alias_declaration",
+		"type_alias_declaration",
+		"type_alias_declaration",
+		"type_alias_declaration",
+		"function_declaration",
+		"function_declaration",
+		"lexical_declaration",
+		"lexical_declaration",
+		"variable_declaration",
+		"lexical_declaration",
+		"class_declaration",
+		"class_declaration",
+		"interface_declaration",
+		"interface_declaration",
+		"enum_declaration",
+		"enum_declaration",
+		"class_declaration",
+		"function_declaration",
+		"lexical_declaration",
+	}
+
+	if len(fileMap.Definitions) != len(expectedTypes) {
+		t.Fatalf("expected %d definitions, got %d", len(expectedTypes), len(fileMap.Definitions))
+	}
+
+	for i, def := range fileMap.Definitions {
+		expectedType := expectedTypes[i]
+		if def.Type != expectedType {
+			t.Errorf("at index %d: expected type %s, got %s", i, expectedType, def.Type)
+		}
+	}
+}

--- a/app/server/syntax/file_map/nodes_config.go
+++ b/app/server/syntax/file_map/nodes_config.go
@@ -817,3 +817,13 @@ var includeAndContinueNodeMap = nodeMap{
 		},
 	},
 }
+
+var unwrapNodeMap = nodeMap{
+	"export_statement": {
+		nodeMatch: matchTypeEqual,
+		languages: langSet{
+			shared.LanguageTypescript: true,
+			shared.LanguageTsx:        true,
+		},
+	},
+}

--- a/app/server/syntax/file_map/nodes_find.go
+++ b/app/server/syntax/file_map/nodes_find.go
@@ -99,6 +99,45 @@ func isIncludeAndContinueNode(node Node) bool {
 	return !config.ignore
 }
 
+func isUnwrapNode(node Node) bool {
+	setNodeType(&node)
+	config := unwrapNodeMap.getConfig(node.Type, node.Lang)
+
+	if config == nil {
+		return false
+	}
+
+	return true
+}
+
+func unwrapNodeIndex(node Node) *int {
+	idx := new(int)
+
+	if isUnwrapNode(node) {
+
+		if node.Lang == shared.LanguageTypescript || node.Lang == shared.LanguageTsx {
+			switch node.TsNode.ChildCount() {
+			case 1:
+				// ???
+				*idx = 0
+				return idx
+			case 2:
+				// export const foo = "bar"
+				*idx = 1
+				return idx
+			case 3:
+				// export default function(){...}
+				*idx = 2
+				return idx
+			default:
+				fmt.Printf("Unexpected number of children for unwrap node: %s (%d)", node.Type, node.TsNode.ChildCount())
+			}
+		}
+	}
+
+	return nil
+}
+
 func (m nodeMap) getConfig(t string, lang shared.Language) *nodeConfig {
 	// first look for exact match
 	config, ok := m[nodeType(t)]


### PR DESCRIPTION
**Problem**
previously any statements that both exported a symbol and declared it were not being included in the map.

its a common pattern in typescript to use these statements, eg:
```typescript
export const FOO = "foo"

export function doSomething(){}

export class MyClass {}
```

which meant that the resulting file maps would be missing many symbols / `[NO MAP]`

**Solution**
this change aims to fix that by "unwrapping" `export_statement` nodes to be the declaration child node that we actually care about.

it additionally sprinkles some more logging around this area, as I lost a lot of time thinking I was using plandex incorrectly initially, before starting to debug/write tests for the plandex server code itself.

**Testing Notes**
on the project I noticed this one, this patch takes things from most files being `[NO MAP]` to every file having a valid looking map