### PR TITLE
remove width restriction for cli

### DIFF
--- a/app/cli/term/format.go
+++ b/app/cli/term/format.go
@@ -41,7 +41,7 @@ func getGlamourRenderer() (*glamour.TermRenderer, error) {
 
 	// Always set word wrap and preserved newlines.
 	opts = append(opts,
-		glamour.WithWordWrap(min(width, 80)),
+		glamour.WithWordWrap(width-2),
 		glamour.WithPreservedNewLines(),
 	)
 
@@ -74,7 +74,7 @@ func GetMarkdown(input string) (string, error) {
 func GetPlain(input string) string {
 	width := GetTerminalWidth()
 
-	s := wordwrap.String(input, min(width-2, 80))
+	s := wordwrap.String(input, width-2)
 	// add padding
 	lines := strings.Split(s, "\n")
 	// for i := range lines {


### PR DESCRIPTION
This PR uncommented the word wrap logic in "app/cli/term/format.go" to respect the full terminal width.
Previously, the word wrap was limited to a maximum of 80 characters ( "min(width, 80)" ), even if the terminal was wider. This allows the output to use the available terminal width (`width-2`).
The terminal width can still be fixed using the `PLANDEX_COLUMNS` environment variable.