### PR TITLE
fix: use env bash shebang for cross-platform compatibility

### DIFF
--- a/app/clear_local.sh
+++ b/app/clear_local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the absolute path to the script's directory, regardless of where it's run from
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/app/reset_local.sh
+++ b/app/reset_local.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Get the absolute path to the script's directory, regardless of where it's run from
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 

--- a/app/start_local.sh
+++ b/app/start_local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the absolute path to the script's directory, regardless of where it's run from
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"


### PR DESCRIPTION
Hello! Hope you're doing well. Thank you so much for such a great tool. plandex significantly differentiates itself with other similar tools I have tried in terms of robust file editing.

## Problem

Current scripts use `#!/bin/bash` which assumes bash is installed in `/bin/`. I'm on NixOS and bash is located elsewhere (e.g., `/nix/store/*/bin/bash`).

### Solution

This PR replaced `#!/bin/bash` with `#!/usr/bin/env bash` for improving portability across Unix-like platforms (at least +1 on making it work on NixOS).

Thank you!