### PR TITLE
feat: add HTTP_PROXY env support when making model API calls

### DIFF
--- a/app/server/model/client.go
+++ b/app/server/model/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"plandex-server/types"
 	"strings"
@@ -32,7 +33,21 @@ const (
 	MAX_RETRY_DELAY_SECONDS              = 10
 )
 
-var httpClient = &http.Client{}
+var httpClient = createHTTPClient()
+
+func createHTTPClient() *http.Client {
+	client := &http.Client{}
+
+	if proxyURL := os.Getenv("HTTP_PROXY"); proxyURL != "" {
+		if parsedURL, err := url.Parse(proxyURL); err == nil {
+			client.Transport = &http.Transport{
+				Proxy: http.ProxyURL(parsedURL),
+			}
+		}
+	}
+
+	return client
+}
 
 type ClientInfo struct {
 	Client   *openai.Client


### PR DESCRIPTION
Hello!

This PR adds support for `HTTP_PROXY` environment variable to specify HTTP proxy server for network connections, which addressed the https://github.com/plandex-ai/plandex/issues/270 bug I have. This `HTTP_PROXY` "feature" is actually the workaround I need in order to plandex without global VPN. Side note: Claude Code also supports [HTTP_PROXY](https://docs.anthropic.com/en/docs/claude-code/settings#environment-variables).

I tried to fix the root cause. I have no idea why plandex still makes direct API calls to OpenAI when `OPENAI_API_KEY` is not set. Regardless, even if the https://github.com/plandex-ai/plandex/issues/270 bug is fixed without needing proxy, I still think adding proxy support is a good feature: If you plan to add other providers like Anthropic or Google, they have geographical restriction as well. So proxy support means without needing to worry about the openrouter fallback order.

## Test

Run the backend locally:

```sh
cd app/server
docker-compose up -d plandex-postgres
export DATABASE_URL=postgres://plandex:plandex@localhost:5432/plandex?sslmode=disable
export LOCAL_MODE=1
export GOENV=development
export PLANDEX_ENV=development
export HTTP_PROXY=http://127.0.0.1:8888
go run .
```

Run the frontend locally:

```sh
cd app/cli/
./dev.sh
./plandex-dev
```

Type `hello` and get response back.

Without `export HTTP_PROXY=http://127.0.0.1:8888` I'd get the following error:

```
2025/05/30 19:27:10.288306 tell_stream_finish.go:123:
Error summarizing convo: 500 Error: error generating plan summary:
error creating chat completion stream:
status code: 403, body: 
{"error":{"message":"Provider returned error","code":403,"metadata"
:{"raw":"{\"error\":{\"code\":\"unsupported_country_region_territory\",
\"message\":\"Country, region, or territory not supported\",
\"param\":null,\"type\":\"request_forbidden\"}}",
"provider_name":"OpenAI"}},"user_id":"user_***"}
```

Thank you again for such a great tool!