### PR TITLE
Modify Postgresql db Path

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - plandex-db:/var/lib/postgresql/data
+      - plandex-db:/var/lib/postgresql
     networks:
       - plandex-network
   plandex-server:


### PR DESCRIPTION
In Postgres 18 the default mount point has changed. `/var/lib/postgresql/data` is no longer valid.

This prevents following the suggested self-hosting instructions without modification.

See line 194 here for evidence of the Postgresql change: https://github.com/docker-library/postgres/blob/22ca5c8d8e4b37bece4d38dbce1a060583b5308a/18/alpine3.22/Dockerfile#L194

Resolves issue #305 