### PR TITLE
fix: Nil pointer dereference on no credits from openrouter

### DIFF
--- a/app/server/model/client_stream.go
+++ b/app/server/model/client_stream.go
@@ -290,7 +290,11 @@ func withStreamingRetries[T any](
 
 		log.Printf("Error in streaming operation: %v, isFallback: %t, numTotalRetry: %d, numFallbackRetry: %d, numRetry: %d, compareRetries: %d, maxRetries: %d\n", err, isFallback, numTotalRetry, numFallbackRetry, numRetry, compareRetries, maxRetries)
 
-		classifyRes := classifyBasicError(err, fallbackRes.BaseModelConfig.HasClaudeMaxAuth)
+		hasClaudeMaxAuth := false
+		if fallbackRes.BaseModelConfig != nil {
+			hasClaudeMaxAuth = fallbackRes.BaseModelConfig.HasClaudeMaxAuth
+		}
+		classifyRes := classifyBasicError(err, hasClaudeMaxAuth)
 		modelErr = &classifyRes
 
 		newFallback := false


### PR DESCRIPTION
## Summary
This PR fixes #304

## Changes
- Added nil check for `fallbackRes.BaseModelConfig` before accessing `HasClaudeMaxAuth` field in `client_stream.go:293-296`
- Prevents nil pointer dereference panic when OpenRouter returns 402 error for insufficient credits
- Maintains backward compatibility by defaulting `hasClaudeMaxAuth` to `false` when `BaseModelConfig` is nil

## Testing
- All existing tests pass successfully
- Code compiles without errors
- Fix follows Go best practices and project conventions

---
Generated with Claude Code