### PR TITLE
fix: prepareEditorCommand doesn't accept arguments

### DIFF
--- a/app/cli/cmd/tell.go
+++ b/app/cli/cmd/tell.go
@@ -142,13 +142,21 @@ func getTellPrompt(args []string) string {
 }
 
 func prepareEditorCommand(editor string, filename string) *exec.Cmd {
-	switch editor {
-	case "vim":
-		return exec.Command(editor, "+normal G$", "+startinsert!", filename)
-	case "nano":
-		return exec.Command(editor, "+99999999", filename)
-	default:
+	parts := strings.Fields(editor)
+	if len(parts) == 0 {
 		return exec.Command(editor, filename)
+	}
+
+	editorName := parts[0]
+	editorArgs := parts[1:]
+
+	switch editorName {
+	case "vim":
+		return exec.Command(editorName, append(editorArgs, "+normal G$", "+startinsert!", filename)...)
+	case "nano":
+		return exec.Command(editorName, append(editorArgs, "+99999999", filename)...)
+	default:
+		return exec.Command(editorName, append(editorArgs, filename)...)
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR fixes #98

## Changes
- Modified `prepareEditorCommand` function in `app/cli/cmd/tell.go` to properly parse editor commands with arguments
- The function now uses `strings.Fields` to split the editor string into the executable name and its arguments
- Arguments from the environment variable (e.g., `--wait` in `zed --wait`) are now properly passed to the editor command
- Maintains backward compatibility with editors specified without arguments
- Preserves special handling for vim and nano editors

## Technical Details
The fix splits the editor command using `strings.Fields(editor)` and extracts:
- `editorName`: the first part (executable)
- `editorArgs`: remaining parts (arguments)

These arguments are then prepended to the editor-specific arguments before the filename, ensuring proper command construction.

---
Generated with Claude Code