### PR TITLE
fix: [FR] write config files into XDG_CONFIG_HOME

### DIFF
--- a/app/cli/fs/fs.go
+++ b/app/cli/fs/fs.go
@@ -17,6 +17,117 @@ var HomeDir string
 var HomeAuthPath string
 var HomeAccountsPath string
 
+// getXDGConfigHome returns XDG_CONFIG_HOME or ~/.config as default
+func getXDGConfigHome(home string) string {
+	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
+		return xdgConfig
+	}
+	return filepath.Join(home, ".config")
+}
+
+// getXDGCacheHome returns XDG_CACHE_HOME or ~/.cache as default
+func getXDGCacheHome(home string) string {
+	if xdgCache := os.Getenv("XDG_CACHE_HOME"); xdgCache != "" {
+		return xdgCache
+	}
+	return filepath.Join(home, ".cache")
+}
+
+// getLegacyHomePlandexDir returns the old ~/.plandex-home-v2 path for migration
+func getLegacyHomePlandexDir(home string) string {
+	if os.Getenv("PLANDEX_ENV") == "development" {
+		return filepath.Join(home, ".plandex-home-dev-v2")
+	}
+	return filepath.Join(home, ".plandex-home-v2")
+}
+
+// migrateLegacyConfig migrates config files from legacy path to XDG path
+func migrateLegacyConfig(legacyDir, newConfigDir, newCacheDir string) {
+	// Check if legacy directory exists
+	if _, err := os.Stat(legacyDir); os.IsNotExist(err) {
+		return
+	}
+
+	// Check if new config directory already has files (don't overwrite)
+	if _, err := os.Stat(filepath.Join(newConfigDir, "auth.json")); err == nil {
+		return
+	}
+
+	// Migrate auth.json
+	legacyAuth := filepath.Join(legacyDir, "auth.json")
+	if _, err := os.Stat(legacyAuth); err == nil {
+		if data, err := os.ReadFile(legacyAuth); err == nil {
+			os.WriteFile(filepath.Join(newConfigDir, "auth.json"), data, 0600)
+		}
+	}
+
+	// Migrate accounts.json
+	legacyAccounts := filepath.Join(legacyDir, "accounts.json")
+	if _, err := os.Stat(legacyAccounts); err == nil {
+		if data, err := os.ReadFile(legacyAccounts); err == nil {
+			os.WriteFile(filepath.Join(newConfigDir, "accounts.json"), data, 0600)
+		}
+	}
+
+	// Migrate cache directory contents
+	legacyCacheDir := filepath.Join(legacyDir, "cache")
+	if _, err := os.Stat(legacyCacheDir); err == nil {
+		// Migrate tiktoken cache
+		legacyTiktoken := filepath.Join(legacyCacheDir, "tiktoken")
+		if entries, err := os.ReadDir(legacyTiktoken); err == nil {
+			newTiktoken := filepath.Join(newCacheDir, "tiktoken")
+			os.MkdirAll(newTiktoken, os.ModePerm)
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					if data, err := os.ReadFile(filepath.Join(legacyTiktoken, entry.Name())); err == nil {
+						os.WriteFile(filepath.Join(newTiktoken, entry.Name()), data, 0644)
+					}
+				}
+			}
+		}
+	}
+
+	// Migrate project-specific files (current-plans-v2.json, settings-v2.json)
+	entries, err := os.ReadDir(legacyDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && entry.Name() != "cache" {
+			// This is likely a project directory
+			projectDir := filepath.Join(legacyDir, entry.Name())
+			newProjectDir := filepath.Join(newConfigDir, entry.Name())
+			os.MkdirAll(newProjectDir, os.ModePerm)
+
+			// Migrate current-plans-v2.json
+			currentPlans := filepath.Join(projectDir, "current-plans-v2.json")
+			if data, err := os.ReadFile(currentPlans); err == nil {
+				os.WriteFile(filepath.Join(newProjectDir, "current-plans-v2.json"), data, 0644)
+			}
+
+			// Migrate plan subdirectories
+			projectEntries, err := os.ReadDir(projectDir)
+			if err != nil {
+				continue
+			}
+			for _, pe := range projectEntries {
+				if pe.IsDir() {
+					// Plan directory
+					planDir := filepath.Join(projectDir, pe.Name())
+					newPlanDir := filepath.Join(newProjectDir, pe.Name())
+					os.MkdirAll(newPlanDir, os.ModePerm)
+
+					// Migrate settings-v2.json
+					settings := filepath.Join(planDir, "settings-v2.json")
+					if data, err := os.ReadFile(settings); err == nil {
+						os.WriteFile(filepath.Join(newPlanDir, "settings-v2.json"), data, 0644)
+					}
+				}
+			}
+		}
+	}
+}
+
 func init() {
 	var err error
 	Cwd, err = os.Getwd()
@@ -30,19 +141,34 @@ func init() {
 	}
 	HomeDir = home
 
+	// Get XDG base directories
+	xdgConfigHome := getXDGConfigHome(home)
+	xdgCacheHome := getXDGCacheHome(home)
+
+	// Set up plandex directories following XDG spec
 	if os.Getenv("PLANDEX_ENV") == "development" {
-		HomePlandexDir = filepath.Join(home, ".plandex-home-dev-v2")
+		HomePlandexDir = filepath.Join(xdgConfigHome, "plandex", "dev-v2")
+		CacheDir = filepath.Join(xdgCacheHome, "plandex", "dev-v2")
 	} else {
-		HomePlandexDir = filepath.Join(home, ".plandex-home-v2")
+		HomePlandexDir = filepath.Join(xdgConfigHome, "plandex", "v2")
+		CacheDir = filepath.Join(xdgCacheHome, "plandex", "v2")
 	}
 
-	// Create the home plandex directory if it doesn't exist
+	// Create the directories if they don't exist
 	err = os.MkdirAll(HomePlandexDir, os.ModePerm)
 	if err != nil {
 		term.OutputErrorAndExit(err.Error())
 	}
 
-	CacheDir = filepath.Join(HomePlandexDir, "cache")
+	err = os.MkdirAll(CacheDir, os.ModePerm)
+	if err != nil {
+		term.OutputErrorAndExit(err.Error())
+	}
+
+	// Migrate from legacy location if needed
+	legacyDir := getLegacyHomePlandexDir(home)
+	migrateLegacyConfig(legacyDir, HomePlandexDir, CacheDir)
+
 	HomeAuthPath = filepath.Join(HomePlandexDir, "auth.json")
 	HomeAccountsPath = filepath.Join(HomePlandexDir, "accounts.json")
 

--- a/docs/docs/hosting/self-hosting/advanced-self-hosting.md
+++ b/docs/docs/hosting/self-hosting/advanced-self-hosting.md
@@ -151,7 +151,17 @@ To resolve this, remove the following in any directory you used the CLI in:
 
 Then run `plandex sign-in` again to create a new account.
 
-If you're still having trouble with accounts, you can also remove the following from your $HOME directory to fully reset them:
+If you're still having trouble with accounts, you can also remove the following to fully reset them:
 
-- `.plandex-home-dev` directory if you ran the CLI with `PLANDEX_ENV=development`
-- `.plandex-home` directory otherwise
+For Plandex v2 (XDG-compliant paths):
+- `$XDG_CONFIG_HOME/plandex/dev-v2` directory if you ran the CLI with `PLANDEX_ENV=development`
+- `$XDG_CONFIG_HOME/plandex/v2` directory otherwise
+- (Default `XDG_CONFIG_HOME` is `~/.config`)
+
+For legacy Plandex v2 installations:
+- `~/.plandex-home-dev-v2` directory if you ran the CLI with `PLANDEX_ENV=development`
+- `~/.plandex-home-v2` directory otherwise
+
+For legacy Plandex v1 installations:
+- `~/.plandex-home-dev` directory if you ran the CLI with `PLANDEX_ENV=development`
+- `~/.plandex-home` directory otherwise


### PR DESCRIPTION
Fixes #284

## Changes
- Use `$XDG_CONFIG_HOME/plandex/v2` for config files (falls back to `~/.config/plandex/v2`)
- Use `$XDG_CACHE_HOME/plandex/v2` for cache files (falls back to `~/.cache/plandex/v2`)
- Migrate existing config from legacy `~/.plandex-home-v2/` path automatically
- Update documentation with new XDG-compliant paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)