### PR TITLE
fix: close HTTP response bodies to prevent resource leaks in CLI API

### DIFF
--- a/app/cli/api/methods.go
+++ b/app/cli/api/methods.go
@@ -51,11 +51,11 @@ func (a *Api) GetCliTrialSession(token string) (*shared.SessionResponse, *shared
 		return nil, &shared.ApiError{Type: shared.ApiErrorTypeOther, Msg: fmt.Sprintf("error sending request: %v", err)}
 	}
 
+	defer resp.Body.Close()
+
 	if resp.StatusCode == 404 {
 		return nil, nil
 	}
-
-	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		errorBody, _ := io.ReadAll(resp.Body)
@@ -582,6 +582,7 @@ func (a *Api) RespondMissingFile(planId, branch string, req shared.RespondMissin
 	if err != nil {
 		return &shared.ApiError{Msg: fmt.Sprintf("error sending request: %v", err)}
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		errorBody, _ := io.ReadAll(resp.Body)
@@ -613,6 +614,7 @@ func (a *Api) ConnectPlan(planId, branch string, onStream types.OnStreamPlan) *s
 	}
 
 	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
 		errorBody, _ := io.ReadAll(resp.Body)
 		apiErr := HandleApiError(resp, errorBody)
 


### PR DESCRIPTION
## Summary

Fix 3 HTTP response body leaks in `app/cli/api/methods.go`:

- **GetCliTrialSession**: `defer resp.Body.Close()` was placed after the early return 
  on 404, so the body was never closed for 404 responses. Moved the defer before the 
  status check.
- **RespondMissingFile**: Completely missing `defer resp.Body.Close()`. The body was 
  never closed on the success path.
- **ConnectPlan**: On error path (status >= 400), the response body was read but never 
  closed. Added `defer resp.Body.Close()` in the error branch. (Success path correctly 
  passes body to stream handler.)

These leaks could cause file descriptor exhaustion under sustained usage.

## Test plan

- [ ] Verify CLI operations work normally after the changes
- [ ] Confirm no resource leaks during extended usage sessions