### PR TITLE
fix: correct copy-paste bugs and missing returns in CLI API methods

### DIFF
--- a/app/cli/api/methods.go
+++ b/app/cli/api/methods.go
@@ -786,7 +786,7 @@ func (a *Api) UnarchivePlan(planId string) *shared.ApiError {
 
 		didRefresh, apiErr := refreshAuthIfNeeded(apiErr)
 		if didRefresh {
-			return a.ArchivePlan(planId)
+			return a.UnarchivePlan(planId)
 		}
 		return apiErr
 	}
@@ -887,7 +887,7 @@ func (a *Api) RejectFile(planId, branch, filePath string) *shared.ApiError {
 		apiErr := HandleApiError(resp, errorBody)
 		didRefresh, apiErr := refreshAuthIfNeeded(apiErr)
 		if didRefresh {
-			a.RejectFile(planId, branch, filePath)
+			return a.RejectFile(planId, branch, filePath)
 		}
 		return apiErr
 	}
@@ -921,7 +921,7 @@ func (a *Api) RejectFiles(planId, branch string, paths []string) *shared.ApiErro
 		apiErr := HandleApiError(resp, errorBody)
 		didRefresh, apiErr := refreshAuthIfNeeded(apiErr)
 		if didRefresh {
-			a.RejectFiles(planId, branch, paths)
+			return a.RejectFiles(planId, branch, paths)
 		}
 		return apiErr
 	}
@@ -2411,7 +2411,7 @@ func (a *Api) AutoLoadContext(ctx context.Context, planId, branch string, req sh
 		apiErr := HandleApiError(resp, errorBody)
 		authRefreshed, apiErr := refreshAuthIfNeeded(apiErr)
 		if authRefreshed {
-			return a.LoadContext(planId, branch, req)
+			return a.AutoLoadContext(ctx, planId, branch, req)
 		}
 		return nil, apiErr
 	}


### PR DESCRIPTION
## Summary

Fix 4 logic bugs in `app/cli/api/methods.go`, all caused by copy-paste errors during 
development:

- **UnarchivePlan** (line 789): After auth refresh, incorrectly called `ArchivePlan` 
  instead of `UnarchivePlan`, causing the exact opposite operation to be performed.
- **RejectFile** (line 890): Missing `return` before recursive call after auth refresh, 
  causing the return value (including potential errors) to be silently discarded.
- **RejectFiles** (line 924): Same missing `return` issue as RejectFile.
- **AutoLoadContext** (line 2414): After auth refresh, called `LoadContext` 
  (endpoint: `/context`) instead of `AutoLoadContext` (endpoint: `/auto_load_context`), 
  hitting the wrong server endpoint.

## Test plan

- [ ] Verify `UnarchivePlan` correctly unarchives a plan after auth token refresh
- [ ] Verify `RejectFile` / `RejectFiles` properly propagate errors after auth refresh
- [ ] Verify `AutoLoadContext` hits `/auto_load_context` endpoint after auth refresh