### PR TITLE
fix: correct bugs in shared utility functions

### DIFF
--- a/app/shared/context.go
+++ b/app/shared/context.go
@@ -180,6 +180,8 @@ func SummaryForLoadContext(contexts []*Context, tokensAdded, totalTokens int) st
 		for i, add := range added {
 			if i == len(added)-1 {
 				msg += ", and " + add
+			} else if i == 0 {
+				msg += add
 			} else {
 				msg += ", " + add
 			}
@@ -288,6 +290,8 @@ func SummaryForUpdateContext(params SummaryForUpdateContextParams) string {
 		for i, add := range toAdd {
 			if i == len(toAdd)-1 {
 				msg += ", and " + add
+			} else if i == 0 {
+				msg += " " + add
 			} else {
 				msg += ", " + add
 			}

--- a/app/shared/utils.go
+++ b/app/shared/utils.go
@@ -131,7 +131,7 @@ func ReplaceReverse(s, old, new string, n int) string {
 	}
 
 	// If n is positive, replace the last n occurrences of old with new
-	var res string
+	res := s
 	for i := 0; i < n; i++ {
 		idx := strings.LastIndex(s, old)
 		if idx == -1 {
@@ -168,6 +168,11 @@ func looksTextish(b []byte) bool {
 		return false
 	}
 
+	total := len(b)
+	if total == 0 {
+		return true
+	}
+
 	printable := 0
 	for len(b) > 0 {
 		r, size := utf8.DecodeRune(b)
@@ -179,5 +184,5 @@ func looksTextish(b []byte) bool {
 			printable++
 		}
 	}
-	return float64(printable)/float64(len(b)) > 0.90 // 3
+	return float64(printable)/float64(total) > 0.90 // 3
 }


### PR DESCRIPTION
## Summary

Fix 4 bugs in shared utility code:

- **looksTextish** (`utils.go`): The function consumed the byte slice `b` in the 
  counting loop, so `len(b)` was always 0 at the division, producing `+Inf` for any 
  non-empty valid UTF-8 input. The printable ratio check was completely ineffective. 
  Fixed by saving the original length before the loop.
- **ReplaceReverse** (`utils.go`): When `old` was not found in `s`, the function 
  returned empty string `""` instead of the original string. This could silently erase 
  content. Fixed by initializing `res = s`.
- **SummaryForLoadContext** (`context.go`): When formatting a list of 3+ items, the 
  first item was prefixed with ", " producing output like `"Loaded , a note, 5 files, 
  and 2 urls"`. Fixed by handling the i==0 case separately.
- **SummaryForUpdateContext** (`context.go`): Same formatting bug as above.

## Test plan

- [ ] Verify `looksTextish` correctly identifies binary vs text content
- [ ] Verify `ReplaceReverse` returns original string when pattern not found
- [ ] Verify context summary messages format correctly with 1, 2, and 3+ items