### PR TITLE
fix: correct multiple server-side bugs in handlers and model client

### DIFF
--- a/app/server/db/plan_helpers.go
+++ b/app/server/db/plan_helpers.go
@@ -177,6 +177,7 @@ func AddPlanConvoMessage(msg *ConvoMessage, branch string) error {
 		_, err := Conn.Exec("UPDATE plans SET total_replies = total_replies + 1 WHERE id = $1", msg.PlanId)
 		if err != nil {
 			errCh <- fmt.Errorf("error updating plan total replies: %v", err)
+			return
 		}
 
 		errCh <- nil

--- a/app/server/handlers/invites.go
+++ b/app/server/handlers/invites.go
@@ -78,11 +78,12 @@ func InviteUserHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid email: "+req.Email, http.StatusBadRequest)
 		return
 	}
-	domain := &split[1]
+	domain := split[1]
 
-	if org.AutoAddDomainUsers && org.Domain == domain {
+	if org.AutoAddDomainUsers && org.Domain != nil && *org.Domain == domain {
 		log.Printf("User already has access to org via domain: %v\n", domain)
-		http.Error(w, "User already has access to org via domain: "+*domain, http.StatusBadRequest)
+		http.Error(w, "User already has access to org via domain: "+domain, http.StatusBadRequest)
+		return
 	}
 
 	// ensure user with this email isn't already in the org

--- a/app/server/handlers/plans_crud.go
+++ b/app/server/handlers/plans_crud.go
@@ -541,12 +541,12 @@ func ListPlansRunningHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sort.Slice(res.Branches, func(i, j int) bool {
-		iComposite := res.Branches[i].PlanId + "|" + res.Branches[i].Name
-		jComposite := res.Branches[j].PlanId + "|" + res.Branches[j].Name
-		iFinishedAt, iOk := res.StreamFinishedAtByBranchId[iComposite]
-		jFinishedAt, jOk := res.StreamFinishedAtByBranchId[jComposite]
-		iCreatedAt := res.StreamStartedAtByBranchId[iComposite]
-		jCreatedAt := res.StreamStartedAtByBranchId[jComposite]
+		iId := res.Branches[i].Id
+		jId := res.Branches[j].Id
+		iFinishedAt, iOk := res.StreamFinishedAtByBranchId[iId]
+		jFinishedAt, jOk := res.StreamFinishedAtByBranchId[jId]
+		iCreatedAt := res.StreamStartedAtByBranchId[iId]
+		jCreatedAt := res.StreamStartedAtByBranchId[jId]
 
 		if iOk && jOk {
 			return iFinishedAt.Before(jFinishedAt) // Sort finished streams by finishedAt in ascending order.

--- a/app/server/model/client_stream.go
+++ b/app/server/model/client_stream.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"plandex-server/types"
 	shared "plandex-shared"
+	"strings"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -41,7 +42,9 @@ func CreateChatCompletionWithInternalStream(
 
 	// choose the fastest provider by latency/throughput on openrouter
 	if baseModelConfig.Provider == shared.ModelProviderOpenRouter {
-		req.Model += ":nitro"
+		if !strings.HasSuffix(string(req.Model), ":nitro") && !strings.HasSuffix(string(req.Model), ":free") && !strings.HasSuffix(string(req.Model), ":floor") {
+			req.Model += ":nitro"
+		}
 	}
 
 	// Force streaming mode since we're using the streaming API


### PR DESCRIPTION
## Summary

Fix 4 server-side bugs:

- **InviteUserHandler** (`invites.go:81-86`): Two bugs in domain check: (1) compared 
  pointer addresses instead of string values (`org.Domain == domain` where both are 
  `*string`), making the check always fail; (2) missing `return` after `http.Error()`, 
  allowing execution to continue and potentially create duplicate invites.
- **CreateChatCompletionWithInternalStream** (`client_stream.go:43-44`): Unconditionally 
  appended `:nitro` to OpenRouter model names without checking for existing suffixes. 
  The non-streaming `CreateChatCompletionStream` in `client.go` correctly checks for 
  `:nitro`, `:free`, and `:floor` suffixes. Added the same check to prevent invalid 
  model names like `model:free:nitro`.
- **AddPlanConvoMessage** (`plan_helpers.go:178-182`): Missing `return` after sending 
  error to `errCh`. When `Exec` failed, both an error and a nil were sent (2 writes), 
  but combined with the first goroutine's write (1 write), that's 3 writes to a channel 
  read only 2 times — the third write blocks forever, leaking the goroutine.
- **ListPlansRunningHandler** (`plans_crud.go:544-549`): Sort function used composite 
  key `PlanId + "|" + Name` to look up `StreamFinishedAtByBranchId` map, but the map 
  was keyed by `branch.Id`. Lookups always missed, making the sort ineffective.

## Test plan

- [ ] Verify invite domain check correctly prevents duplicate invites
- [ ] Verify OpenRouter models with `:free` or `:floor` suffix work in streaming mode
- [ ] Verify no goroutine leaks when plan reply count update fails
- [ ] Verify running plans list is correctly sorted by stream status