### PR TITLE
Add Qiniu Cloud (七牛云) as a built-in model provider

### DIFF
--- a/app/shared/ai_models_available.go
+++ b/app/shared/ai_models_available.go
@@ -325,6 +325,7 @@ var BuiltInModels = []*BaseModelConfigSchema{
 		Providers: []BaseModelUsesProvider{
 			{Provider: ModelProviderDeepSeek, ModelName: "deepseek/deepseek-chat"},
 			{Provider: ModelProviderOpenRouter, ModelName: "deepseek/deepseek-chat-v3"},
+			{Provider: ModelProviderQiniu, ModelName: "deepseek-v3"},
 		},
 	},
 	{
@@ -343,6 +344,7 @@ var BuiltInModels = []*BaseModelConfigSchema{
 		Providers: []BaseModelUsesProvider{
 			{Provider: ModelProviderDeepSeek, ModelName: "deepseek/deepseek-reasoner"},
 			{Provider: ModelProviderOpenRouter, ModelName: "deepseek/deepseek-r1-0528"},
+			{Provider: ModelProviderQiniu, ModelName: "deepseek-r1"},
 		},
 	},
 	{
@@ -581,6 +583,34 @@ var BuiltInModels = []*BaseModelConfigSchema{
 		Providers: []BaseModelUsesProvider{
 			{Provider: ModelProviderPerplexity, ModelName: "sonar-reasoning-online"},
 			{Provider: ModelProviderOpenRouter, ModelName: "perplexity/sonar-reasoning"},
+		},
+	},
+
+	// Qiniu Cloud (七牛云) models via AI Inference Hub (api.qnaigc.com)
+	{
+		ModelTag:    "qiniu/kimi-k2",
+		Publisher:   ModelPublisherQwen,
+		Description: "Kimi K2 (via Qiniu)",
+		BaseModelShared: BaseModelShared{
+			DefaultMaxConvoTokens: 15000, MaxTokens: 256000,
+			MaxOutputTokens: 16384, ReservedOutputTokens: 16384,
+			PreferredOutputFormat: ModelOutputFormatXml,
+		},
+		Providers: []BaseModelUsesProvider{
+			{Provider: ModelProviderQiniu, ModelName: "moonshotai/kimi-k2.5"},
+		},
+	},
+	{
+		ModelTag:    "qiniu/glm-5",
+		Publisher:   ModelPublisherQwen,
+		Description: "GLM-5 (via Qiniu)",
+		BaseModelShared: BaseModelShared{
+			DefaultMaxConvoTokens: 15000, MaxTokens: 128000,
+			MaxOutputTokens: 8192, ReservedOutputTokens: 8192,
+			PreferredOutputFormat: ModelOutputFormatXml,
+		},
+		Providers: []BaseModelUsesProvider{
+			{Provider: ModelProviderQiniu, ModelName: "z-ai/glm-5"},
 		},
 	},
 }

--- a/app/shared/ai_models_providers.go
+++ b/app/shared/ai_models_providers.go
@@ -15,6 +15,7 @@ const GoogleAIStudioApiKeyEnvVar = "GEMINI_API_KEY"
 const AzureOpenAIEnvVar = "AZURE_OPENAI_API_KEY"
 const DeepSeekApiKeyEnvVar = "DEEPSEEK_API_KEY"
 const PerplexityApiKeyEnvVar = "PERPLEXITY_API_KEY"
+const QiniuApiKeyEnvVar = "QINIU_API_KEY"
 
 // not set directly via env vars, but used for auth var resolution
 const AnthropicClaudeMaxTokenEnvVar = "ANTHROPIC_CLAUDE_MAX_TOKEN"
@@ -46,6 +47,7 @@ const (
 	ModelProviderAzureOpenAI        ModelProvider = "azure-openai"
 	ModelProviderDeepSeek           ModelProvider = "deepseek"
 	ModelProviderPerplexity         ModelProvider = "perplexity"
+	ModelProviderQiniu              ModelProvider = "qiniu"
 
 	ModelProviderAmazonBedrock ModelProvider = "aws-bedrock"
 
@@ -72,6 +74,7 @@ var AllModelProviders = []ModelProvider{
 	ModelProviderAmazonBedrock,
 	ModelProviderDeepSeek,
 	ModelProviderPerplexity,
+	ModelProviderQiniu,
 	ModelProviderOllama,
 	ModelProviderCustom,
 }
@@ -215,6 +218,11 @@ var BuiltInModelProviderConfigs = map[ModelProvider]ModelProviderConfigSchema{
 		BaseUrl:   LiteLLMBaseUrl,
 		SkipAuth:  true,
 		LocalOnly: true,
+	},
+	ModelProviderQiniu: {
+		Provider:     ModelProviderQiniu,
+		BaseUrl:      "https://api.qnaigc.com/v1",
+		ApiKeyEnvVar: QiniuApiKeyEnvVar,
 	},
 }
 


### PR DESCRIPTION
## Summary

This PR adds [Qiniu Cloud AI Inference Hub](https://developer.qiniu.com/aitokenapi) (七牛云) as a built-in model provider.

Qiniu Cloud provides an OpenAI-compatible API at `https://api.qnaigc.com/v1` with access to 50+ mainstream large models, making it straightforward to integrate as a native Plandex provider.

### Changes

- **`app/shared/ai_models_providers.go`**
  - Add `ModelProviderQiniu` constant (`"qiniu"`)
  - Add `QiniuApiKeyEnvVar` constant (`"QINIU_API_KEY"`)
  - Register `ModelProviderQiniu` in `AllModelProviders`
  - Add provider config in `BuiltInModelProviderConfigs` with base URL `https://api.qnaigc.com/v1`

- **`app/shared/ai_models_available.go`**
  - Add Qiniu as an additional provider for `deepseek/v3` (model ID: `deepseek-v3`) and `deepseek/r1` (model ID: `deepseek-r1`)
  - Add `qiniu/kimi-k2` model — Moonshot AI Kimi K2.5, 256K context window
  - Add `qiniu/glm-5` model — Zhipu AI GLM-5, 128K context window

### Setup

Users need to set one environment variable:

```bash
export QINIU_API_KEY=<your_api_key>
```

API keys can be obtained at https://portal.qiniu.com/ai-inference/api-key. New users receive 3 million free tokens.

### No `client.go` changes needed

Qiniu's API is fully OpenAI-compatible, so the existing `newClient()` generic path handles it without any provider-specific logic.

### References

- API docs: https://developer.qiniu.com/aitokenapi/12882/ai-inference-api
- Chat completions: https://developer.qiniu.com/aitokenapi/13211/chat_completions
- Model list: https://developer.qiniu.com/aitokenapi (query `/v1/models` for full list)

## Test plan

- [ ] Set `QINIU_API_KEY` and verify Qiniu provider appears in `plandex models available`
- [ ] Test `deepseek/v3` via Qiniu provider
- [ ] Test `deepseek/r1` via Qiniu provider
- [ ] Test `qiniu/kimi-k2` model
- [ ] Test `qiniu/glm-5` model

🤖 Generated with [Claude Code](https://claude.com/claude-code)