### PR TITLE
fix: prevent HTTP response body leaks in CLI API methods

### DIFF
--- a/app/cli/api/methods.go
+++ b/app/cli/api/methods.go
@@ -51,11 +51,11 @@ func (a *Api) GetCliTrialSession(token string) (*shared.SessionResponse, *shared
 		return nil, &shared.ApiError{Type: shared.ApiErrorTypeOther, Msg: fmt.Sprintf("error sending request: %v", err)}
 	}
 
+	defer resp.Body.Close()
+
 	if resp.StatusCode == 404 {
 		return nil, nil
 	}
-
-	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		errorBody, _ := io.ReadAll(resp.Body)
@@ -487,6 +487,7 @@ func (a *Api) TellPlan(planId, branch string, req shared.TellPlanRequest, onStre
 	if err != nil {
 		return &shared.ApiError{Msg: fmt.Sprintf("error sending request: %v", err)}
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		errorBody, _ := io.ReadAll(resp.Body)
@@ -503,9 +504,6 @@ func (a *Api) TellPlan(planId, branch string, req shared.TellPlanRequest, onStre
 	if req.ConnectStream {
 		log.Println("Connecting stream")
 		connectPlanRespStream(resp.Body, onStream)
-	} else {
-		// log.Println("Background exec - not connecting stream")
-		resp.Body.Close()
 	}
 
 	return nil
@@ -538,6 +536,7 @@ func (a *Api) BuildPlan(planId, branch string, req shared.BuildPlanRequest, onSt
 	if err != nil {
 		return &shared.ApiError{Msg: fmt.Sprintf("error sending request: %v", err)}
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		log.Println("Error response from build plan", resp.StatusCode)
@@ -556,9 +555,6 @@ func (a *Api) BuildPlan(planId, branch string, req shared.BuildPlanRequest, onSt
 	if req.ConnectStream {
 		log.Println("Connecting stream")
 		connectPlanRespStream(resp.Body, onStream)
-	} else {
-		// log.Println("Background exec - not connecting stream")
-		resp.Body.Close()
 	}
 
 	return nil
@@ -582,6 +578,7 @@ func (a *Api) RespondMissingFile(planId, branch string, req shared.RespondMissin
 	if err != nil {
 		return &shared.ApiError{Msg: fmt.Sprintf("error sending request: %v", err)}
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		errorBody, _ := io.ReadAll(resp.Body)
@@ -611,6 +608,7 @@ func (a *Api) ConnectPlan(planId, branch string, onStream types.OnStreamPlan) *s
 	if err != nil {
 		return &shared.ApiError{Msg: fmt.Sprintf("error sending request: %v", err)}
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		errorBody, _ := io.ReadAll(resp.Body)


### PR DESCRIPTION
## Summary

Several API methods in `app/cli/api/methods.go` had HTTP response body leak issues:

- **`GetCliTrialSession`**: `defer resp.Body.Close()` was placed after an early return on 404, so the body was never closed on that path
- **`TellPlan`**: No `defer resp.Body.Close()` at all — body only closed in the non-streaming branch, leaked on error paths
- **`BuildPlan`**: Same pattern as TellPlan
- **`RespondMissingFile`**: No `defer resp.Body.Close()` anywhere
- **`ConnectPlan`**: No `defer resp.Body.Close()` — body leaked on error paths

These leaks can cause resource exhaustion in long-running CLI sessions, especially when many API calls are made in succession.

## Changes

- Moved or added `defer resp.Body.Close()` immediately after the response is received in all affected methods
- Removed redundant explicit `resp.Body.Close()` calls that are now covered by defer

## Test plan

- [ ] Verify existing tests still pass
- [ ] Manual testing of `plandex tell`, `plandex build`, and `plandex connect` commands
- [ ] Verify no regressions in streaming response handling