### PR TITLE
fix: replace panic() with log.Fatalf() in init functions

### DIFF
--- a/app/server/db/fs.go
+++ b/app/server/db/fs.go
@@ -12,7 +12,7 @@ var BaseDir string
 func init() {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		panic(fmt.Errorf("error getting user home dir: %v", err))
+		log.Fatalf("error getting user home dir: %v", err)
 	}
 
 	log.Println("Plandex server home dir:", home)

--- a/app/server/db/git.go
+++ b/app/server/db/git.go
@@ -25,7 +25,7 @@ func init() {
 	// ensure git is available
 	cmd := exec.Command("git", "--version")
 	if err := cmd.Run(); err != nil {
-		panic(fmt.Errorf("error running git --version: %v", err))
+		log.Fatalf("git is not available: %v", err)
 	}
 }
 

--- a/app/shared/ai_models_available.go
+++ b/app/shared/ai_models_available.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"log"
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
@@ -664,51 +665,51 @@ func init() {
 	for _, model := range AvailableModels {
 		if model.Description == "" {
 			spew.Dump(model)
-			panic("description is not set")
+			log.Fatalf("model validation failed: description is not set")
 		}
 
 		if model.Provider == "" {
 			spew.Dump(model)
-			panic("model provider is not set")
+			log.Fatalf("model validation failed: model provider is not set")
 		}
 		if model.ModelId == "" {
 			spew.Dump(model)
-			panic("model id is not set")
+			log.Fatalf("model validation failed: model id is not set")
 		}
 
 		if model.DefaultMaxConvoTokens == 0 {
 			spew.Dump(model)
-			panic("default max convo tokens is not set")
+			log.Fatalf("model validation failed: default max convo tokens is not set")
 		}
 
 		if model.MaxTokens == 0 {
 			spew.Dump(model)
-			panic("max tokens is not set")
+			log.Fatalf("model validation failed: max tokens is not set")
 		}
 
 		if model.MaxOutputTokens == 0 {
 			spew.Dump(model)
-			panic("max output tokens is not set")
+			log.Fatalf("model validation failed: max output tokens is not set")
 		}
 
 		if model.ReservedOutputTokens == 0 {
 			spew.Dump(model)
-			panic("reserved output tokens is not set")
+			log.Fatalf("model validation failed: reserved output tokens is not set")
 		}
 
 		if model.ApiKeyEnvVar == "" && len(model.ExtraAuthVars) == 0 && !model.SkipAuth && !model.HasAWSAuth && !model.HasClaudeMaxAuth {
 			spew.Dump(model)
-			panic("api key or auth settings are not set")
+			log.Fatalf("model validation failed: api key or auth settings are not set")
 		}
 
 		if model.BaseUrl == "" {
 			spew.Dump(model)
-			panic("base url is not set")
+			log.Fatalf("model validation failed: base url is not set")
 		}
 
 		if model.PreferredOutputFormat == "" {
 			spew.Dump(model)
-			panic("preferred model output format is not set")
+			log.Fatalf("model validation failed: preferred model output format is not set")
 		}
 
 		compositeKey := string(model.Provider) + "/" + string(model.ModelId)


### PR DESCRIPTION
## Summary

Fixes #337

Replaces `panic()` calls with `log.Fatalf()` in three `init()` functions. Panics produce noisy goroutine stack traces that obscure the actual error. `log.Fatalf()` logs a clear message and exits cleanly.

## Changes

- **`app/shared/ai_models_available.go`**: 10 `panic()` → `log.Fatalf()` in model validation loop, with `"model validation failed: "` prefix
- **`app/server/db/fs.go`**: `panic(fmt.Errorf(...))` → `log.Fatalf(...)` for home dir detection
- **`app/server/db/git.go`**: `panic(fmt.Errorf(...))` → `log.Fatalf(...)` for git availability check

## Rationale

Since these are `init()` functions (cannot return errors), `log.Fatalf()` is the appropriate replacement — it provides a clean error message and `os.Exit(1)` instead of a panic trace.

## Test plan

- [ ] Verify compilation: `go build ./...`
- [ ] Trigger a validation failure (e.g., empty model description) and confirm clean error output
- [ ] Normal startup should be unaffected