### PR TITLE
fix: unset TERMINFO before keyboard.Open() to fix tmux terminal support

### DIFF
--- a/app/cli/term/prompt.go
+++ b/app/cli/term/prompt.go
@@ -69,6 +69,17 @@ func GetUserPasswordInput(msg string) (string, error) {
 }
 
 func GetUserKeyInput() (rune, keyboard.Key, error) {
+	// Temporarily unset TERMINFO so the keyboard library falls through to
+	// TERMINFO_DIRS and standard system paths (e.g. /usr/share/terminfo).
+	// Without this, terminals like Ghostty set $TERMINFO to a directory that
+	// only contains their own entries; when running inside tmux the library
+	// then fails to locate tmux-256color and returns "Unsupported terminal".
+	// See: https://github.com/plandex-ai/plandex/issues/320
+	if terminfo := os.Getenv("TERMINFO"); terminfo != "" {
+		os.Unsetenv("TERMINFO")
+		defer os.Setenv("TERMINFO", terminfo)
+	}
+
 	if err := keyboard.Open(); err != nil {
 		return 0, 0, fmt.Errorf("failed to open keyboard: %s", err)
 	}


### PR DESCRIPTION
Fixes #320

## Problem

When a terminal emulator (e.g. Ghostty) sets `$TERMINFO` to a private directory containing only its own terminfo entries, the `eiannone/keyboard` library uses that directory exclusively — it does not fall through to `$TERMINFO_DIRS` or standard system paths. As a result, when running inside tmux, the library cannot locate `tmux-256color` and returns an "Unsupported terminal" error, which surfaces as:

```
🚨 Error confirming
  → Failed to get user input
    → Failed to open keyboard
      → Error while reading terminfo data:termbox
        → Unsupported terminal
```

This affects any user whose terminal sets `$TERMINFO` to a terminal-specific directory (Ghostty, Alacritty with custom terminfo, etc.) when also using tmux.

## Solution

Temporarily unset `$TERMINFO` inside `GetUserKeyInput()` before calling `keyboard.Open()`. This allows the library to search `$TERMINFO_DIRS` and standard system paths (e.g. `/usr/share/terminfo`) where `tmux-256color` is available. The original value is restored via `defer` when the function returns.

The change is limited to the keyboard open call and does not affect any other behavior.

## Testing

Reproduced locally by setting `TERMINFO=/tmp/empty-terminfo TERM=tmux-256color` and confirming that without the fix `keyboard.Open()` fails, while with the fix it succeeds by falling through to system terminfo paths.