### PR TITLE
docs: clarify OLLAMA_BASE_URL supports any Ollama-compatible server

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -27,8 +27,16 @@ services:
       GOENV: development
       LOCAL_MODE: 1
       PLANDEX_BASE_DIR: /plandex-server
+      # OLLAMA_BASE_URL sets the base URL for local Ollama-compatible inference.
+      # Change this if your Ollama server is running on a different host or port,
+      # or if you're using another Ollama-API-compatible server (e.g. vLLM with
+      # --api-base ollama, LM Studio in Ollama mode). Remove or comment out this
+      # line if you're not using any local Ollama-compatible models.
+      # To use a non-Ollama OpenAI-compatible API (e.g. vLLM in OpenAI mode),
+      # configure it as a custom model provider via the Plandex CLI instead:
+      # https://docs.plandex.ai/models/model-providers#custom-models
       OLLAMA_BASE_URL: http://host.docker.internal:11434
-      
+
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -89,7 +89,7 @@ API_HOST= # The host the API server listens on. Defaults to 'http://localhost:$P
 PORT=8099 # The port the server listens on. Defaults to 8099.
 DATABASE_URL= # The URL of the PostgreSQL database. Defaults to 'postgres://plandex:plandex@plandex-postgres:5432/plandex?sslmode=disable' in development mode
 LOCAL_MODE= # Whether to run in local mode
-OLLAMA_BASE_URL= # The base URL of the Ollama server—only need when the server is running in a Docker container and needs to access Ollama models running outside of the container
+OLLAMA_BASE_URL= # The base URL of the Ollama server—only needed when the server is running in a Docker container and needs to access Ollama models running outside of the container. This can point to any Ollama-API-compatible server (e.g. vLLM with --api-base ollama, LM Studio in Ollama mode). For other OpenAI-compatible servers, use custom model providers via the CLI instead.
 ```
 
 ### docker-compose


### PR DESCRIPTION
Fixes #321

## Problem

The `docker-compose.yml` and `environment-variables.md` documentation implied that `OLLAMA_BASE_URL` is exclusively for Ollama, causing confusion for users who want to use other local inference servers like vLLM. The question "Plandex Docker compose is Ollama only?" comes from this ambiguity.

## Solution

- Added explanatory comments to `docker-compose.yml` clarifying that `OLLAMA_BASE_URL` can point to **any Ollama-API-compatible server**, not just Ollama (e.g. vLLM in Ollama mode, LM Studio in Ollama mode).
- Noted that the variable can be removed/commented out if no local Ollama-compatible models are being used.
- Noted that for non-Ollama OpenAI-compatible servers (vLLM in standard OpenAI mode), users should use the custom model providers feature instead.
- Updated `docs/docs/environment-variables.md` with the same clarifications.

## Testing

Documentation-only change, no functional code was modified.