### PR TITLE
fix: avoid stream retry panic on missing model config

### DIFF
--- a/app/server/model/client_stream.go
+++ b/app/server/model/client_stream.go
@@ -290,7 +290,8 @@ func withStreamingRetries[T any](
 
 		log.Printf("Error in streaming operation: %v, isFallback: %t, numTotalRetry: %d, numFallbackRetry: %d, numRetry: %d, compareRetries: %d, maxRetries: %d\n", err, isFallback, numTotalRetry, numFallbackRetry, numRetry, compareRetries, maxRetries)
 
-		classifyRes := classifyBasicError(err, fallbackRes.BaseModelConfig.HasClaudeMaxAuth)
+		isClaudeMax := fallbackRes.BaseModelConfig != nil && fallbackRes.BaseModelConfig.HasClaudeMaxAuth
+		classifyRes := classifyBasicError(err, isClaudeMax)
 		modelErr = &classifyRes
 
 		newFallback := false

--- a/app/server/model/client_stream_test.go
+++ b/app/server/model/client_stream_test.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	shared "plandex-shared"
+)
+
+func TestWithStreamingRetriesHandlesMissingBaseModelConfig(t *testing.T) {
+	attempts := 0
+	overloadedErr := &HTTPError{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       `{"type":"error","error":{"type":"overloaded_error","message":"The server cluster is currently under high load"}}`,
+	}
+
+	_, err := withStreamingRetries(context.Background(), func(numRetry int, didProviderFallback bool, modelErr *shared.ModelError) (*string, shared.FallbackResult, error) {
+		attempts++
+		return nil, shared.FallbackResult{
+			ModelRoleConfig: &shared.ModelRoleConfig{},
+			IsFallback:      false,
+			BaseModelConfig: nil,
+		}, overloadedErr
+	}, func(resp *string, err error) {})
+
+	if err == nil {
+		t.Fatal("expected overloaded error after retries are exhausted")
+	}
+	if attempts != MAX_RETRIES_WITHOUT_FALLBACK+1 {
+		t.Fatalf("expected %d attempts, got %d", MAX_RETRIES_WITHOUT_FALLBACK+1, attempts)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #339.

When a streaming LLM call returns an overloaded/rate-limit error and the fallback result does not include a base model config, `withStreamingRetries` dereferenced `fallbackRes.BaseModelConfig` while classifying the error. That could turn the original provider error into a nil pointer panic.

This change treats a missing base model config as non-Claude-Max for classification, preserving the original retry/error handling path instead of panicking.

## Test plan

- `PATH=/home/bobo/.local/go-toolchain/go/bin:$PATH go test ./model -run TestWithStreamingRetriesHandlesMissingBaseModelConfig -count=1`
- `PATH=/home/bobo/.local/go-toolchain/go/bin:$PATH go test ./model`
- `PATH=/home/bobo/.local/go-toolchain/go/bin:$PATH go test ./...`
