### PR TITLE
Add Requesty as a built-in model provider

### DIFF
--- a/app/cli/schema/json-schemas/definitions/model-providers.schema.json
+++ b/app/cli/schema/json-schemas/definitions/model-providers.schema.json
@@ -5,6 +5,7 @@
   "description": "The built-in model providers that Plandex supports. Use 'custom' for a provider that is not built-in.",
   "enum": [
     "openrouter",
+    "requesty",
     "openai",
     "anthropic",
     "google-ai-studio",

--- a/app/shared/ai_models_available.go
+++ b/app/shared/ai_models_available.go
@@ -105,6 +105,7 @@ var BuiltInModels = []*BaseModelConfigSchema{
 			{Provider: ModelProviderOpenAI, ModelName: "gpt-4.1"},
 			{Provider: ModelProviderAzureOpenAI, ModelName: "azure/gpt-4.1"},
 			{Provider: ModelProviderOpenRouter, ModelName: "openai/gpt-4.1"},
+			{Provider: ModelProviderRequesty, ModelName: "openai/gpt-4.1"},
 		},
 	},
 	{
@@ -120,6 +121,7 @@ var BuiltInModels = []*BaseModelConfigSchema{
 			{Provider: ModelProviderOpenAI, ModelName: "gpt-4.1-mini"},
 			{Provider: ModelProviderAzureOpenAI, ModelName: "azure/gpt-4.1-mini"},
 			{Provider: ModelProviderOpenRouter, ModelName: "openai/gpt-4.1-mini"},
+			{Provider: ModelProviderRequesty, ModelName: "openai/gpt-4.1-mini"},
 		},
 	},
 	{
@@ -284,6 +286,7 @@ var BuiltInModels = []*BaseModelConfigSchema{
 			{Provider: ModelProviderGoogleAIStudio, ModelName: "gemini/gemini-2.5-pro"},
 			{Provider: ModelProviderGoogleVertex, ModelName: "vertex_ai/gemini-2.5-pro"},
 			{Provider: ModelProviderOpenRouter, ModelName: "google/gemini-2.5-pro"},
+			{Provider: ModelProviderRequesty, ModelName: "google/gemini-2.5-pro"},
 		},
 	},
 	{
@@ -311,6 +314,7 @@ var BuiltInModels = []*BaseModelConfigSchema{
 			{Provider: ModelProviderGoogleAIStudio, ModelName: "gemini/gemini-2.5-flash"},
 			{Provider: ModelProviderGoogleVertex, ModelName: "vertex_ai/gemini-2.5-flash"},
 			{Provider: ModelProviderOpenRouter, ModelName: "google/gemini-2.5-flash"},
+			{Provider: ModelProviderRequesty, ModelName: "google/gemini-2.5-flash"},
 		},
 	},
 	{

--- a/app/shared/ai_models_providers.go
+++ b/app/shared/ai_models_providers.go
@@ -6,10 +6,12 @@ import (
 
 const OpenAIV1BaseUrl = "https://api.openai.com/v1"
 const OpenRouterBaseUrl = "https://openrouter.ai/api/v1"
+const RequestyBaseUrl = "https://router.requesty.ai/v1"
 const LiteLLMBaseUrl = "http://localhost:4000/v1" // runs in the same container alongside the plandex server
 
 const OpenAIEnvVar = "OPENAI_API_KEY"
 const OpenRouterApiKeyEnvVar = "OPENROUTER_API_KEY"
+const RequestyApiKeyEnvVar = "REQUESTY_API_KEY"
 const AnthropicApiKeyEnvVar = "ANTHROPIC_API_KEY"
 const GoogleAIStudioApiKeyEnvVar = "GEMINI_API_KEY"
 const AzureOpenAIEnvVar = "AZURE_OPENAI_API_KEY"
@@ -37,6 +39,7 @@ type ModelProvider string
 
 const (
 	ModelProviderOpenRouter ModelProvider = "openrouter"
+	ModelProviderRequesty   ModelProvider = "requesty"
 	ModelProviderOpenAI     ModelProvider = "openai"
 
 	ModelProviderAnthropic          ModelProvider = "anthropic"
@@ -63,6 +66,7 @@ var ModelProviderToLiteLLMId = map[ModelProvider]string{
 
 var AllModelProviders = []ModelProvider{
 	ModelProviderOpenRouter,
+	ModelProviderRequesty,
 	ModelProviderOpenAI,
 	ModelProviderAnthropic,
 	ModelProviderAnthropicClaudeMax,
@@ -129,6 +133,11 @@ var BuiltInModelProviderConfigs = map[ModelProvider]ModelProviderConfigSchema{
 		Provider:     ModelProviderOpenRouter,
 		BaseUrl:      OpenRouterBaseUrl,
 		ApiKeyEnvVar: OpenRouterApiKeyEnvVar,
+	},
+	ModelProviderRequesty: {
+		Provider:     ModelProviderRequesty,
+		BaseUrl:      RequestyBaseUrl,
+		ApiKeyEnvVar: RequestyApiKeyEnvVar,
 	},
 	ModelProviderAnthropic: {
 		Provider:     ModelProviderAnthropic,

--- a/docs/docs/models/model-providers.md
+++ b/docs/docs/models/model-providers.md
@@ -56,6 +56,20 @@ You can also use OpenRouter alongside other providers. For example, if you set b
 
 If you set a `OPENROUTER_API_KEY` and are also using other providers, Plandex will also **fail over** to OpenRouter if another provider has an error. This offers a strong layer of redundancy since OpenRouter itself routes model calls across a number of different upstream providers.
 
+### Requesty
+
+[Requesty](https://requesty.ai/) is an OpenAI-compatible LLM gateway that, like OpenRouter, lets you reach models from multiple publishers through a single account and API key.
+
+To use Requesty, create an account and generate an API key, then set the `REQUESTY_API_KEY` environment variable.
+
+```bash
+export REQUESTY_API_KEY=...
+
+plandex # start the Plandex REPL
+```
+
+Requesty uses the same `publisher/model` naming convention as OpenRouter (e.g. `openai/gpt-4.1`, `google/gemini-2.5-flash`) and can be combined with other providers in the same way—direct providers take precedence when their credentials are also set. See the [Requesty model list](https://app.requesty.ai/router/list) for available models.
+
 ### OpenAI
 
 You can optionally set an `OPENAI_API_KEY` to use the OpenAI API directly with your own OpenAI account when calling OpenAI models.


### PR DESCRIPTION
This adds Requesty (https://requesty.ai), an OpenAI-compatible LLM gateway, as a built-in model provider. The wiring mirrors the existing OpenRouter provider.

Like OpenRouter, Requesty exposes an OpenAI-compatible API and uses the same `publisher/model` naming convention (e.g. `openai/gpt-4.1`, `google/gemini-2.5-flash`), so it slots into the existing provider model with no new abstractions.

Changes:
- `app/shared/ai_models_providers.go`: add the `requesty` provider constant, the `REQUESTY_API_KEY` env var, the `https://router.requesty.ai/v1` base URL, the entry in `AllModelProviders`, and the `BuiltInModelProviderConfigs` registration (base URL + API key env var), mirroring the OpenRouter entry.
- `app/shared/ai_models_available.go`: add Requesty as an additional provider option on a small set of models where the Requesty model name matches the existing OpenRouter model name exactly: `openai/gpt-4.1`, `openai/gpt-4.1-mini`, `google/gemini-2.5-flash`, `google/gemini-2.5-pro`.
- `app/cli/schema/json-schemas/definitions/model-providers.schema.json`: add `requesty` to the provider enum.
- `docs/docs/models/model-providers.md`: add a Requesty section under Built-In Providers.

I kept this minimal rather than wiring Requesty onto every model: I only added it to models whose name maps 1:1 to a Requesty model I verified routes successfully. Anthropic models were intentionally left out for now because Requesty's current naming (e.g. `anthropic/claude-sonnet-4-5`) doesn't line up exactly with Plandex's existing `anthropic/claude-sonnet-4` model name, and I didn't want to introduce an incorrect mapping. Happy to extend coverage if maintainers prefer.

Testing:
- `go build ./...` passes in `app/shared`, `app/cli`, and `app/server`.
- `go vet ./...` passes in `app/shared`.
- `gofmt` clean on the changed Go files.
- Live calls to `https://router.requesty.ai/v1/chat/completions` returned HTTP 200 for each model added: `openai/gpt-4.1`, `openai/gpt-4.1-mini`, `google/gemini-2.5-flash`, and `google/gemini-2.5-pro`.

Disclosure: I work at Requesty. This mirrors the existing OpenRouter provider; happy to adjust wording/placement or close if it's not a fit.
