### PR TITLE
Add Atlas Cloud model provider

### DIFF
--- a/app/shared/ai_models_atlascloud_test.go
+++ b/app/shared/ai_models_atlascloud_test.go
@@ -1,0 +1,36 @@
+package shared
+
+import "testing"
+
+func TestAtlasCloudProviderConfig(t *testing.T) {
+	config, ok := BuiltInModelProviderConfigs[ModelProviderAtlasCloud]
+	if !ok {
+		t.Fatal("expected Atlas Cloud provider config")
+	}
+
+	if config.BaseUrl != AtlasCloudBaseUrl {
+		t.Fatalf("expected Atlas Cloud base URL %q, got %q", AtlasCloudBaseUrl, config.BaseUrl)
+	}
+
+	if config.ApiKeyEnvVar != AtlasCloudApiKeyEnvVar {
+		t.Fatalf("expected Atlas Cloud API key env var %q, got %q", AtlasCloudApiKeyEnvVar, config.ApiKeyEnvVar)
+	}
+}
+
+func TestAtlasCloudBuiltInModels(t *testing.T) {
+	deepSeek := GetAvailableModel(ModelProviderAtlasCloud, "atlascloud/deepseek-v4-pro")
+	if deepSeek == nil {
+		t.Fatal("expected Atlas Cloud DeepSeek V4 Pro model")
+	}
+	if deepSeek.ModelName != "deepseek-ai/deepseek-v4-pro" {
+		t.Fatalf("expected DeepSeek V4 Pro model name, got %q", deepSeek.ModelName)
+	}
+
+	qwen := GetAvailableModel(ModelProviderAtlasCloud, "atlascloud/qwen3.5-flash")
+	if qwen == nil {
+		t.Fatal("expected Atlas Cloud Qwen3.5 Flash model")
+	}
+	if qwen.ModelName != "qwen/qwen3.5-flash" {
+		t.Fatalf("expected Qwen3.5 Flash model name, got %q", qwen.ModelName)
+	}
+}

--- a/app/shared/ai_models_available.go
+++ b/app/shared/ai_models_available.go
@@ -346,6 +346,23 @@ var BuiltInModels = []*BaseModelConfigSchema{
 		},
 	},
 	{
+		ModelTag:    "atlascloud/deepseek-v4-pro",
+		Publisher:   ModelPublisherDeepSeek,
+		Description: "DeepSeek V4 Pro via Atlas Cloud",
+		BaseModelShared: BaseModelShared{
+			DefaultMaxConvoTokens: 15000, MaxTokens: 1000000,
+			MaxOutputTokens: 32768, ReservedOutputTokens: 8192,
+			PreferredOutputFormat: ModelOutputFormatXml,
+		},
+		Variants: []BaseModelConfigVariant{
+			{VariantTag: "visible", IsDefaultVariant: true, Description: "(reasoning visible)", Overrides: BaseModelShared{IncludeReasoning: true}},
+			{VariantTag: "hidden", Description: "(reasoning hidden)", Overrides: BaseModelShared{IncludeReasoning: false}},
+		},
+		Providers: []BaseModelUsesProvider{
+			{Provider: ModelProviderAtlasCloud, ModelName: "deepseek-ai/deepseek-v4-pro"},
+		},
+	},
+	{
 		ModelTag:    "deepseek/r1-70b",
 		Publisher:   ModelPublisherDeepSeek,
 		Description: "DeepSeek R1 70B",
@@ -409,6 +426,19 @@ var BuiltInModels = []*BaseModelConfigSchema{
 		},
 		Providers: []BaseModelUsesProvider{
 			{Provider: ModelProviderOpenRouter, ModelName: "qwen/qwen-2.5-coder-32b-instruct"},
+		},
+	},
+	{
+		ModelTag:    "atlascloud/qwen3.5-flash",
+		Publisher:   ModelPublisherQwen,
+		Description: "Qwen3.5 Flash via Atlas Cloud",
+		BaseModelShared: BaseModelShared{
+			DefaultMaxConvoTokens: 10000, MaxTokens: 131072,
+			MaxOutputTokens: 8192, ReservedOutputTokens: 8192,
+			PreferredOutputFormat: ModelOutputFormatXml,
+		},
+		Providers: []BaseModelUsesProvider{
+			{Provider: ModelProviderAtlasCloud, ModelName: "qwen/qwen3.5-flash"},
 		},
 	},
 	{

--- a/app/shared/ai_models_providers.go
+++ b/app/shared/ai_models_providers.go
@@ -6,10 +6,12 @@ import (
 
 const OpenAIV1BaseUrl = "https://api.openai.com/v1"
 const OpenRouterBaseUrl = "https://openrouter.ai/api/v1"
+const AtlasCloudBaseUrl = "https://api.atlascloud.ai/v1"
 const LiteLLMBaseUrl = "http://localhost:4000/v1" // runs in the same container alongside the plandex server
 
 const OpenAIEnvVar = "OPENAI_API_KEY"
 const OpenRouterApiKeyEnvVar = "OPENROUTER_API_KEY"
+const AtlasCloudApiKeyEnvVar = "ATLASCLOUD_API_KEY"
 const AnthropicApiKeyEnvVar = "ANTHROPIC_API_KEY"
 const GoogleAIStudioApiKeyEnvVar = "GEMINI_API_KEY"
 const AzureOpenAIEnvVar = "AZURE_OPENAI_API_KEY"
@@ -38,6 +40,7 @@ type ModelProvider string
 const (
 	ModelProviderOpenRouter ModelProvider = "openrouter"
 	ModelProviderOpenAI     ModelProvider = "openai"
+	ModelProviderAtlasCloud ModelProvider = "atlascloud"
 
 	ModelProviderAnthropic          ModelProvider = "anthropic"
 	ModelProviderAnthropicClaudeMax ModelProvider = "anthropic-pro"
@@ -64,6 +67,7 @@ var ModelProviderToLiteLLMId = map[ModelProvider]string{
 var AllModelProviders = []ModelProvider{
 	ModelProviderOpenRouter,
 	ModelProviderOpenAI,
+	ModelProviderAtlasCloud,
 	ModelProviderAnthropic,
 	ModelProviderAnthropicClaudeMax,
 	ModelProviderGoogleAIStudio,
@@ -129,6 +133,11 @@ var BuiltInModelProviderConfigs = map[ModelProvider]ModelProviderConfigSchema{
 		Provider:     ModelProviderOpenRouter,
 		BaseUrl:      OpenRouterBaseUrl,
 		ApiKeyEnvVar: OpenRouterApiKeyEnvVar,
+	},
+	ModelProviderAtlasCloud: {
+		Provider:     ModelProviderAtlasCloud,
+		BaseUrl:      AtlasCloudBaseUrl,
+		ApiKeyEnvVar: AtlasCloudApiKeyEnvVar,
 	},
 	ModelProviderAnthropic: {
 		Provider:     ModelProviderAnthropic,


### PR DESCRIPTION
## Summary
- add Atlas Cloud as a built-in OpenAI-compatible model provider using `ATLASCLOUD_API_KEY` and `https://api.atlascloud.ai/v1`
- expose Atlas-hosted DeepSeek V4 Pro and Qwen3.5 Flash in the built-in model catalog
- add focused shared package coverage for the provider config and Atlas model registrations

## Validation
- `git diff --check`
- confirmed `deepseek-ai/deepseek-v4-pro` and `qwen/qwen3.5-flash` are present in the Atlas Cloud model list
- unable to run Go tests locally because this environment does not have `go`/`gofmt` installed

No README changes.
