### PR TITLE
fix: add path containment check to prevent path traversal (CWE-22)

### DIFF
--- a/app/cli/lib/apply.go
+++ b/app/cli/lib/apply.go
@@ -636,6 +636,23 @@ func ApplyFiles(toApply map[string]string, toRemove map[string]bool, projectPath
 		go func(path, content string) {
 			// Compute destination path
 			dstPath := filepath.Join(fs.ProjectRoot, path)
+
+			// Security: prevent path traversal (CWE-22). The `path` originates
+			// from the model's output and may contain parent-directory segments
+			// like `../` that could escape the project root.
+			cleanDst, err := filepath.Abs(filepath.Clean(dstPath))
+			if err == nil {
+				cleanRoot, _ := filepath.Abs(filepath.Clean(fs.ProjectRoot))
+				if !strings.HasPrefix(cleanDst, cleanRoot) {
+					log.Printf(
+						"Path traversal blocked: %q attempted to escape project root %q",
+						path, fs.ProjectRoot,
+					)
+					errCh <- nil
+					return
+				}
+			}
+
 			content = strings.ReplaceAll(content, "\\`\\`\\`", "```")
 			// Check if the file exists
 			var exists bool
@@ -701,6 +718,20 @@ func ApplyFiles(toApply map[string]string, toRemove map[string]bool, projectPath
 			}
 			// Compute destination path
 			dstPath := filepath.Join(fs.ProjectRoot, path)
+
+			// Security: prevent path traversal (CWE-22)
+			cleanDst, err := filepath.Abs(filepath.Clean(dstPath))
+			if err == nil {
+				cleanRoot, _ := filepath.Abs(filepath.Clean(fs.ProjectRoot))
+				if !strings.HasPrefix(cleanDst, cleanRoot) {
+					log.Printf(
+						"Path traversal blocked (delete): %q attempted to escape project root %q",
+						path, fs.ProjectRoot,
+					)
+					errCh <- nil
+					return
+				}
+			}
 			// Check if the file exists
 			var exists bool
 			var mode os.FileMode


### PR DESCRIPTION
## Description

Fixes [#352](https://github.com/plandex-ai/plandex/issues/352) - Path traversal vulnerability (CWE-22, CVSS 7.8).

The `ApplyFiles` function in `app/cli/lib/apply.go` constructs destination file paths using `filepath.Join(fs.ProjectRoot, path)` where `path` comes directly from the model's output. Without containment validation, a model output containing `../` sequences can write files anywhere on the host filesystem.

This is especially dangerous in `--auto-apply` mode which proceeds without user confirmation, making it exploitable via indirect prompt injection.

## Fix

Added a containment check after each `filepath.Join` call in both the `toApply` (file write) and `toRemove` (file delete) goroutines:
1. Resolves the absolute, cleaned path with `filepath.Abs(filepath.Clean(dstPath))`
2. Verifies the result starts with the project root using `strings.HasPrefix`
3. If the path escapes the project root, logs a warning and skips the operation silently

Closes #352