### PR TITLE
docs: add OmniRoute custom provider example

### DIFF
--- a/docs/docs/models/custom-models.md
+++ b/docs/docs/models/custom-models.md
@@ -91,6 +91,48 @@ Define providers that use OpenAI-compatible APIs:
 - `skipAuth` - Set to `true` for local models that don't need authentication
 - `extraAuthVars` - Additional authentication variables if needed
 
+### OmniRoute
+
+[OmniRoute](https://github.com/diegosouzapw/OmniRoute) exposes an OpenAI-compatible API,
+so self-hosted Plandex can use it as a custom provider without a provider-specific adapter:
+
+```json
+{
+  "providers": [
+    {
+      "name": "omniroute",
+      "baseUrl": "http://localhost:20128/v1",
+      "apiKeyEnvVar": "OMNIROUTE_API_KEY"
+    }
+  ]
+}
+```
+
+Plandex appends `/chat/completions` to `baseUrl`, so keep the `/v1` suffix. The URL must be
+reachable from the Plandex server; when Plandex runs in Docker, use the OmniRoute container name
+or another host address instead of `localhost` when the services are in different containers.
+
+Set the API key before starting Plandex:
+
+```bash
+export OMNIROUTE_API_KEY=...
+```
+
+Then add a custom model whose provider mapping references `omniroute` and whose `modelName` is an
+exact model ID exposed by OmniRoute:
+
+```json
+{
+  "provider": "custom",
+  "customProvider": "omniroute",
+  "modelName": "provider/model-id"
+}
+```
+
+Use the model's real context and output limits in the surrounding custom model definition. Model
+discovery is not automatic, so choose the model ID from OmniRoute before importing the file with
+`plandex models custom`.
+
 ## Custom Models
 
 Define models with their capabilities and provider mappings:


### PR DESCRIPTION
## Summary

Document how self-hosted Plandex can use OmniRoute through the existing custom
OpenAI-compatible provider support.

## Why

Plandex already supports configurable OpenAI-compatible providers, and OmniRoute
exposes its Chat Completions API at `/v1/chat/completions`. No provider-specific
runtime adapter is required, but the base URL convention is important because
Plandex appends `/chat/completions` itself.

## Changes

- add an OmniRoute custom provider example;
- document the required `/v1` base URL;
- document `OMNIROUTE_API_KEY`;
- clarify Docker/server reachability;
- show how a custom model references the provider;
- clarify that model IDs and capability limits must be configured manually.

## Validation

- `npm run build` in `docs/`
- JSON provider example parsed successfully
- `git diff --check`

Go tests could not be executed in the preparation environment because the Go
toolchain was not installed. This patch only changes documentation.
