### PR TITLE
Support XDG config home for CLI state

### DIFF
--- a/app/cli/fs/fs.go
+++ b/app/cli/fs/fs.go
@@ -30,11 +30,7 @@ func init() {
 	}
 	HomeDir = home
 
-	if os.Getenv("PLANDEX_ENV") == "development" {
-		HomePlandexDir = filepath.Join(home, ".plandex-home-dev-v2")
-	} else {
-		HomePlandexDir = filepath.Join(home, ".plandex-home-v2")
-	}
+	HomePlandexDir = getHomePlandexDir(home, os.Getenv("XDG_CONFIG_HOME"), os.Getenv("PLANDEX_ENV"))
 
 	// Create the home plandex directory if it doesn't exist
 	err = os.MkdirAll(HomePlandexDir, os.ModePerm)
@@ -84,6 +80,20 @@ func FindOrCreatePlandex() (string, bool, error) {
 	ProjectRoot = Cwd
 
 	return dir, true, nil
+}
+
+func getHomePlandexDir(home, xdgConfigHome, plandexEnv string) string {
+	if xdgConfigHome != "" && filepath.IsAbs(xdgConfigHome) {
+		if plandexEnv == "development" {
+			return filepath.Join(xdgConfigHome, "plandex-dev")
+		}
+		return filepath.Join(xdgConfigHome, "plandex")
+	}
+
+	if plandexEnv == "development" {
+		return filepath.Join(home, ".plandex-home-dev-v2")
+	}
+	return filepath.Join(home, ".plandex-home-v2")
 }
 
 func ProjectRootIsGitRepo() bool {

--- a/app/cli/fs/fs_test.go
+++ b/app/cli/fs/fs_test.go
@@ -1,0 +1,42 @@
+package fs
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGetHomePlandexDirUsesXDGConfigHome(t *testing.T) {
+	got := getHomePlandexDir("/home/me", "/tmp/xdg", "")
+	want := filepath.Join("/tmp/xdg", "plandex")
+
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestGetHomePlandexDirUsesXDGConfigHomeForDevelopment(t *testing.T) {
+	got := getHomePlandexDir("/home/me", "/tmp/xdg", "development")
+	want := filepath.Join("/tmp/xdg", "plandex-dev")
+
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestGetHomePlandexDirFallsBackToLegacyHomeDir(t *testing.T) {
+	got := getHomePlandexDir("/home/me", "", "")
+	want := filepath.Join("/home/me", ".plandex-home-v2")
+
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestGetHomePlandexDirIgnoresRelativeXDGConfigHome(t *testing.T) {
+	got := getHomePlandexDir("/home/me", "relative", "")
+	want := filepath.Join("/home/me", ".plandex-home-v2")
+
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Store Plandex CLI home state under `$XDG_CONFIG_HOME/plandex` when `XDG_CONFIG_HOME` is set
- Keep the existing `~/.plandex-home-v2` and development fallback paths when XDG is unset or relative
- Add focused tests for XDG, development, legacy fallback, and relative XDG behavior

Fixes #7

## Tests
- `go test ./fs`
- `go test ./...`